### PR TITLE
Closes #10 - ak_loc fix

### DIFF
--- a/module_configuration.py
+++ b/module_configuration.py
@@ -77,7 +77,8 @@ def configure_server_module(mod_path, ak_loc):
 
 def run(mod_path, ak_loc):
     mod_path = mod_path.rstrip("/")  # remove trailing slash
-    ak_loc = ak_loc.rstrip("/")  # remove trailing slash
+    if ak_loc:
+        ak_loc = ak_loc.rstrip("/")  # remove trailing slash
 
     client_path = mod_path + "/client"
     server_path = mod_path + "/server"


### PR DESCRIPTION
This adds a check that ak_loc is set before attempting the strip. This is needed because `--ak` is not a required argument when a module only has client side code.

Resolves #10