### PR TITLE
Closes #19 - Move Install Instructions to `INSTALL.md`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,43 @@
+#arkouda-contrib Package Installations
+
+`module_configuration.py` is used for installation of packages. This will handle packages that are client only and those that include server modules. The script is configured to print the commands required to run arkouda with your desired package.
+
+##Pull the Package(s) from GitHub
+
+You can either clone the entire `arkouda-contrib` repository or use sparse-checkout to only checkout the packages you will be using.
+
+```commandline
+# Clone entire Repository
+git clone https://github.com/Bears-R-Us/arkouda-contrib.git
+
+# Only Checkout Desired Packages
+mkdir arkouda_ext
+cd arkouda_ext
+git init
+git remote add origin -f https://github.com/Bears-R-Us/arkouda-contrib.git
+touch .git/info/sparse-checkout
+
+# Repeat this echo for all packages you would like to checkout
+echo "<pkg_name>" >> .git/info/sparse-checkout
+
+git pull origin main
+```
+
+##Install a Package
+
+Currently, `module_configuration.py` only supports installing a single package. If your package contains server elements, you will only be able to use a single package. Additional client-only modules could be installed. `module_configuration.py` will print the commands necessary to install a package. This output can be piped to `bash` to automatically execute the installation.
+
+<em>Note - Support for installing multiple modules is being tracked by [Issue #8](https://github.com/Bears-R-Us/arkouda-contrib/issues/8).</em>
+
+###Installation Parameters
+- `path` - this is the full path to the module you want to configure. This should be pathed to the top level folder containing the `client`, `server` and `test` directories.*REQUIRED*
+- `ak` - this is the full path to the Arkouda installation on your machine. *REQUIRED when module contains a server element only*.
+
+###Installation
+```commandline
+# Dry Run - only prints commands
+python3 module_configuration.py --path <path to module> --ak <path to arkouda>
+
+# Run the produced commands and install package
+python3 module_configuration.py --path <path to module> --ak <path to arkouda> | bash
+```

--- a/README.md
+++ b/README.md
@@ -13,25 +13,10 @@ a place for contributed functionality for arkouda
 
 ## Installation
 
-`module_configuration.py` is provided for easy set up. Currently, the script will print out commands that can be copied and run to configure Arkouda with your module or piped into bash for immediate execution.
+Installation is performed by running `module_configuration.py`. For detailed package installation instructions please view [INSTALL.md](https://github.com/Bears-R-Us/arkouda-contrib/blob/main/INSTALL.md).
 
-```commandline
-# To see the commands that will be run
-python3 module_configuration.py --path=<path_to_module> --ak=<path_to_arkouda>
 
-# To automatically run the commands
-python3 module_configuration.py --path=<path_to_module> --ak=<path_to_arkouda> | bash
-```
-
-### Install Parameters
-- `path` - this is the full path to the module you want to configure. *REQUIRED*
-- `ak` - this is the full path to the Arkouda installation on your machine. *REQUIRED when module contains a server element only*.
-
-```commandline
-python3 module_configuration.py --path <path to module> --ak <path to arkouda>
-```
-
-#### Defining Tests
+## Defining Tests
 
 In the `test` directory of your module, you will need to define testing for the newly defined functionality. At the same level as your `test` directory, be sure to define `pytest.ini`.
 


### PR DESCRIPTION
This PR (closes #19):

- `README.md` has been updated to link to `INSTALL.md` for installation instructions.
- Details on pulling packages from the repository for install added to `INSTALL.md`. Option to clone the entire repository or only pull the packages desired.
- Notes added indicating current install workflow limitations and that these will be addressed by Issue #8.