### PR TITLE
Closes #9 typegard to arkouda_distance package

### DIFF
--- a/arkouda_distance/client/arkouda_distance/distance.py
+++ b/arkouda_distance/client/arkouda_distance/distance.py
@@ -4,25 +4,30 @@ from arkouda import pdarray
 from arkouda.pdarrayclass import sum
 
 import math
+from typeguard import typechecked
 
 
 # dot product or two arkouda pdarrays
+@typechecked
 def dot(u: pdarray, v: pdarray):
     return sum(u * v)
 
 
 # magnitude/L_2-norm of arkouda pdarray
+@typechecked
 def magnitude(u: pdarray):
     return math.sqrt(dot(u, u))
 
 
 # cosine distance of two arkouda pdarrays
 # should function similarly to scipy.spatial.distance.cosine
+@typechecked
 def cosine(u: pdarray, v: pdarray):
     return 1.0 - dot(u, v) / (magnitude(u) * magnitude(v))
 
 
 # euclidean distance of two arkouda pdarrays
 # should function similarly to scipy.spatial.distance.euclidean
+@typechecked
 def euclidean(u: pdarray, v: pdarray):
     return math.sqrt(dot(u, u) + dot(v, v) - 2*dot(u, v))

--- a/arkouda_distance/client/setup.py
+++ b/arkouda_distance/client/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='arkouda_distance',
-    version='0.0.1',
+    version='0.0.2',
     description='Distance Computations for Arkouda pdarrays.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/arkouda_distance/test/distance_test.py
+++ b/arkouda_distance/test/distance_test.py
@@ -25,3 +25,16 @@ class DistanceTest(ArkoudaTest):
         b = ak.arange(3, 6, 1)
         e = akd.euclidean(a, b)
         self.assertEqual(e, 5.196152422706632)
+
+    def test_error_handling(self):
+        with self.assertRaises(TypeError):
+            d = akd.dot(14, 14)
+
+        with self.assertRaises(TypeError):
+            m = akd.magnitude('a')
+
+        with self.assertRaises(TypeError):
+            c = akd.cosine('a', 15)
+
+        with self.assertRaises(TypeError):
+            e = akd.euclidean(ak.array['a', 'b', 'c'], [1, 2, 3])


### PR DESCRIPTION
This PR (closes #9):

Adds `@typechecked` to functions where explicit type checking was removed from the function.

Adds a test of the error handling when bad types are passed in.