### PR TITLE
Closes #8 - Multiple External Modules

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,13 +25,16 @@ git pull origin main
 
 ##Install a Package
 
-Currently, `module_configuration.py` only supports installing a single package. If your package contains server elements, you will only be able to use a single package. Additional client-only modules could be installed. `module_configuration.py` will print the commands necessary to install a package. This output can be piped to `bash` to automatically execute the installation.
+`module_configuration.py` allows external Arkouda packages to be installed. If your package contains server elements, you will only be able to use a single package. Additional client-only modules could be installed. `module_configuration.py` will print the commands necessary to install a package. This output can be piped to `bash` to automatically execute the installation.
 
-<em>Note - Support for installing multiple modules is being tracked by [Issue #8](https://github.com/Bears-R-Us/arkouda-contrib/issues/8).</em>
+*Note - Support for installing multiple modules is being tracked by [Issue #8](https://github.com/Bears-R-Us/arkouda-contrib/issues/8).*
 
 ###Installation Parameters
-- `path` - this is the full path to the module you want to configure. This should be pathed to the top level folder containing the `client`, `server` and `test` directories.*REQUIRED*
-- `ak` - this is the full path to the Arkouda installation on your machine. *REQUIRED when module contains a server element only*.
+- `--pkg_path` or `-p` - this is the full path to the module you want to configure. This should be pathed to the top level folder containing the `client`, `server` and `test` directories. **REQUIRED**
+- `--ak_loc` or `-a` - this is the full path to the Arkouda installation on your machine. **REQUIRED when module contains a server element only**.
+- `--config_loc` or `c` - path to save temporary .cfg file to when building arkouda. Defaults to the users home directory (~). **OPTIONAL**
+- `--from_parent` - indicates that the `--pkg_path` being supplied is a parent directory whose child nodes are packages to install. Useful if packages share the same parent directory.
+- `--from_file` - indicates that the `--pkg_path` being supplied is a .txt file containing a newline, `(\n)`, delimited list of paths to packages to install. Useful if packages do not have the same parent directory.
 
 ###Installation
 ```commandline

--- a/module_configuration.py
+++ b/module_configuration.py
@@ -11,24 +11,30 @@ import time
 import pkg_resources as pr
 import subprocess
 
+PIP_INSTALLS = []
+USER_MODS = []
+ADD_TO_CONFIG = []
+
 
 def install_client_pkg(client_path):
+    global PIP_INSTALLS
     """
     Install the python package if not already installed.
     :param client_path: absolute path to module
     """
     # get list of installed pkgs
-    installed_pkgs = {pkg.key for pkg in pr.working_set}
-    if 'pip' not in installed_pkgs:
-        raise RuntimeError("pip is required for the client installation and is not installed.")
-    if not os.path.exists(client_path+"/setup.py"):
-        raise RuntimeError(f"Configuration requires a setup.py file to install client. Please configure {client_path}/setup.py")
-    p = subprocess.Popen(["python3", f"{client_path}/setup.py", "--name"])
-    pkg_name, error = p.communicate()
 
+    if not os.path.exists(client_path + "/setup.py"):
+        raise RuntimeError("Configuration requires a setup.py file to install client. "
+                           f"Please configure {client_path}/setup.py")
+    p = subprocess.check_output(["python3", f"{client_path}/setup.py", "--name"], universal_newlines=True)
+    PIP_INSTALLS.append(client_path)
     # Only provide install command if not already installed on system
-    if pkg_name not in installed_pkgs:
-        print(f"pip install {client_path}")
+    # installed_pkgs = {pkg.key for pkg in pr.working_set}
+    # if pkg_name not in installed_pkgs:
+    #     print(f"pip install {client_path}")
+
+    # TODO - else update already installed package
 
 
 def get_server_modules(cfg):
@@ -46,60 +52,173 @@ def get_chpl_files(mod_path):
 
 
 def configure_server_module(mod_path, ak_loc):
-    if not ak_loc:
-        raise RuntimeError("--ak option is required when configuring a module with server components.")
+    global ADD_TO_CONFIG, USER_MODS
+
     mod_cfg = mod_path + "/server/ServerModules.cfg"
-    ak_cfg = ak_loc + "/ServerModules.cfg"
-    if not os.path.exists(mod_cfg):
-        raise RuntimeError(f"Could not locate module ServerModules.cfg: {mod_cfg}")
-    if not os.path.exists(ak_cfg):
-        raise RuntimeError(f"Could not locate arkouda ServerModules.cfg: {ak_cfg}")
+    # ak_cfg = ak_loc + "/ServerModules.cfg"
 
     # get all of the modules listed in the .cfg file
     mods = get_server_modules(mod_cfg)
+    ADD_TO_CONFIG += mods
 
     # Get chpl files that will be added to arkouda
     c_files = get_chpl_files(mod_path)
+    USER_MODS += c_files
 
     # Generate commands - these can be piped into a shell for execution
     # 1 make copy of the Arkouda ServerModules.cfg
-    tmp_cfg = f"{mod_path}/TmpServerModules.cfg.{int(time.time())}"
+    # tmp_cfg = f"{mod_path}/TmpServerModules.cfg.{int(time.time())}"
+    # print(f"cp {ak_cfg} {tmp_cfg}")
+
+    # 2 append our modules
+    # for c in mods:
+    # print(f"echo {c} >> {tmp_cfg}")
+
+    # 3 generate make command with vars
+    # ak_srv_user_mods = '"' + " ".join(c_files) + '"' # setup our ARKOUDA_SERVER_USER_MODULES
+    # print(f"ARKOUDA_SERVER_USER_MODULES={ak_srv_user_mods} ARKOUDA_CONFIG_FILE={tmp_cfg} "
+    # f"ARKOUDA_SKIP_CHECK_DEPS=true make -C {ak_loc}")
+
+
+def validate_pkgs(pkg_list, ak_loc):
+    """
+    Validate that all packages are configured as required and provide errors if not
+
+    :param pkg_list: List of full paths to packages
+    :param ak_loc: string path to arkouda
+    :return: None
+    """
+    # Pip is required to install client pkgs, verify if is installed.
+    installed_pkgs = {pkg.key for pkg in pr.working_set}
+    if 'pip' not in installed_pkgs:
+        raise RuntimeError("pip is required for the client installation. Please install pip.")
+
+    ak_checked = False
+    for pkg in pkg_list:
+        # Verify that the pkg path exists
+        if not os.path.exists(pkg):
+            raise RuntimeError(f"Package Not Found. {pkg} does not exist.")
+        client_path = pkg + "/client"
+        server_path = pkg + "/server"
+        # Verify the client package configuration
+        if not os.path.exists(client_path):
+            raise RuntimeError(f"Invalid package. Client package not found. {pkg}")
+        if not os.path.exists(client_path + "/setup.py"):
+            raise RuntimeError(f"Invalid Package Configuration. Missing setup.py. {pkg}")
+
+        # Verify the server module configuration
+        if os.path.exists(server_path):
+            # If the arkouda location has not yet been checked, validate it exists.
+            if not ak_checked:
+                if ak_loc:
+                    if not os.path.exists(ak_loc):
+                        raise RuntimeError(f"Arkouda Location not provided or invalid. Set using --ak argument."
+                                           f" Provided: {ak_loc}")
+                    ak_cfg = ak_loc + "/ServerModules.cfg"
+                    if not os.path.exists(ak_cfg):
+                        raise RuntimeError(f"Could not locate arkouda ServerModules.cfg: {ak_cfg}")
+                else:
+                    raise RuntimeError(f"Arkouda Location not provided or invalid. Set using --ak argument."
+                                       f" Provided: {ak_loc}")
+                ak_checked = True
+
+            # Verify that ServerModules.cfg exists for the module
+            mod_cfg = server_path + "/ServerModules.cfg"
+            if not os.path.exists(mod_cfg):
+                raise RuntimeError(f"Could not locate module ServerModules.cfg: {mod_cfg}")
+
+
+def create_commands(ak_loc, config_loc):
+    # install clients
+    print(f"pip install {' '.join(PIP_INSTALLS)}")
+
+    # Create modified config file with user modules - .cfg saved to user home directory
+    ak_cfg = ak_loc + "/ServerModules.cfg"
+    tmp_cfg = f"{config_loc}/TmpServerModules.cfg.{int(time.time())}"
     print(f"cp {ak_cfg} {tmp_cfg}")
 
-    #2 append our modules
-    for c in mods:
+    for c in ADD_TO_CONFIG:
         print(f"echo {c} >> {tmp_cfg}")
 
-    #3 generate make command with vars
-    ak_srv_user_mods = '"' + " ".join(c_files) + '"' # setup our ARKOUDA_SERVER_USER_MODULES
+    ak_srv_user_mods = '"' + " ".join(USER_MODS) + '"'  # setup our ARKOUDA_SERVER_USER_MODULES
     print(f"ARKOUDA_SERVER_USER_MODULES={ak_srv_user_mods} ARKOUDA_CONFIG_FILE={tmp_cfg} "
           f"ARKOUDA_SKIP_CHECK_DEPS=true make -C {ak_loc}")
 
-def run(mod_path, ak_loc):
-    mod_path = mod_path.rstrip("/")  # remove trailing slash
-    if ak_loc:
-        ak_loc = ak_loc.rstrip("/")  # remove trailing slash
 
-    client_path = mod_path + "/client"
-    server_path = mod_path + "/server"
+def run(pkg_list, ak_loc, config_loc):
+    # If only single pkg being installed, convert to list
+    if isinstance(pkg_list, str):
+        pkg_list = [pkg_list.rstrip("/")]
 
-    if os.path.exists(mod_path):
+    # All packages reviewed at once. This prevents partial installs and alerts user to issues sooner.
+    validate_pkgs(pkg_list, ak_loc)
+
+    # Configure the components needed to build install commands
+    for pkg in pkg_list:
+        pkg = pkg.rstrip("/")  # remove trailing slash
+        if ak_loc:
+            ak_loc = ak_loc.rstrip("/")  # remove trailing slash
+
+        client_path = pkg + "/client"
+        server_path = pkg + "/server"
+
         install_client_pkg(client_path)
         if os.path.exists(server_path):
-            if os.path.exists(ak_loc): # only require the arkouda location if server module present
-                configure_server_module(mod_path, ak_loc)
-            else:
-                raise RuntimeError("Arkouda Location must be provided when module contains a server element.")
-    else:
-        raise RuntimeError(f"Module path not valid: {mod_path}")
+            configure_server_module(pkg, ak_loc)
+
+    create_commands(ak_loc, config_loc)
+
+
+def get_package_list_from_file(path):
+    # Verify we have a text file
+    if not path.endswith('.txt'):
+        raise RuntimeError("Package List must be a newline(\n) delimited text file.")
+
+    # read lines of the file and strip whitespace
+    with open(path, 'r') as f:
+        pkg_list = [line.rstrip().rstrip("/") for line in f]
+
+    # Verify that we are not given an empty list
+    if not pkg_list:
+        raise RuntimeError("No packages found to be installed. "
+                           "Please provide a file with a minimum of 1 package location.")
+
+    return pkg_list
+
+
+def get_package_list_from_directory(path):
+    # Verify the provided parent directory exists
+    if not os.path.exists(path):
+        raise RuntimeError(f"Specified parent directory does not exist. {path} Not Found.")
+    if not os.path.isdir(path):
+        raise RuntimeError(f"Specified parent directory is not a directory. {path} is not a directory.")
+
+    pkg_list = [path.rstrip("/") + "/" + x for x in os.listdir(path) if os.path.isdir(os.path.join(path, x)) and
+                not x.startswith('.') and not x.startswith('__')]
+    return pkg_list
+
 
 if __name__ == "__main__":
     parser = optparse.OptionParser()
-    parser.add_option("--path", dest="module", help="Full Path to external module you would like to configure, REQUIRED")
-    parser.add_option("--ak", dest="arkouda", help="Full Path to Arkouda installation, required when a server module provided.")
+    parser.add_option("--from_file", dest="pkg_list_file", action="store_true", default=False,
+                      help="Indicates that your supplied pkg_path will be a file listing the packages to be installed.")
+    parser.add_option("--from_parent", dest="parent_dir", action="store_true", default=False,
+                      help="Indicates that your supplied pkg_path will be a directory containing all pkgs to be installed.")
+    parser.add_option("-p", "--pkg_path", dest="pkg",
+                      help="Full Path to external module you would like to configure, REQUIRED")
+    parser.add_option("-a", "--ak_loc", dest="arkouda",
+                      help="Full Path to Arkouda installation, required when a server module provided.")
+    parser.add_option("-c", "--config_loc", dest="config_location", default="~",
+                      help="Indicates the directory to save the temporary configuration files to. Defaults to ~/.")
     (options, args) = parser.parse_args()
 
-    if not options.module:
-        print("--path is REQUIRED, but was empty.")
+    if not options.pkg:
+        print("--pkg_path/-p is REQUIRED, but was empty.")
+    elif options.pkg_list_file:
+        pkg_list = get_package_list_from_file(options.pkg)
+        run(pkg_list, options.arkouda, options.config_location)
+    elif options.parent_dir:
+        pkg_list = get_package_list_from_directory(options.pkg)
+        run(pkg_list, options.arkouda, options.config_location)
     else:
-        run(options.module, options.arkouda)
+        run(options.pkg, options.arkouda, options.config_location)


### PR DESCRIPTION
This PR (closes #8):

Updates `module_configuration.py` to be able to install multiple packages in one execution. This also allows for the server to be configured to install multiple modules instead of only allowing a single server side install.

Added arguments for users to pass in lists of packages. 

Updated INSTALL.md to reflect new arguments and remove text stating that only single install is supported.