### PR TITLE
Fix md files header pound signs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-#Contributing to arkouda-contrib
+# Contributing to arkouda-contrib
 
 arkouda-contrib welcomes contributions via feedback, bug reports, and pull requests.
 
 We use a simple [Git Feature Branch Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow).
 
-##Development
+## Development
 All packages are required to contain `client` and `test` directories. The `server` directory is utilized when your package requires additional processing code on the Arkouda server.
 
 ### Package Structure
@@ -25,7 +25,7 @@ All packages are required to contain `client` and `test` directories. The `serve
 
 The top level of your package should be added under the `arkouda-contrib` directory. This is the top level of the repository.
 
-##Testing
+## Testing
 
 In the `test` directory of your package, you will need to define testing for the newly defined functionality. At the same level as your `test` directory, be sure to define `pytest.ini`. Example definition below:
 
@@ -58,5 +58,5 @@ To run your tests,
 python3 -m pytest /path_to_module/test/test_file.py
 ```
 
-##PR Submissions
+## PR Submissions
 arkouda-contrib asks that when submitting a PR, you link the issue you are closing to the PR.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,8 +1,8 @@
-#arkouda-contrib Package Installations
+# arkouda-contrib Package Installations
 
 `module_configuration.py` is used for installation of packages. This will handle packages that are client only and those that include server modules. The script is configured to print the commands required to run arkouda with your desired package.
 
-##Pull the Package(s) from GitHub
+## Pull the Package(s) from GitHub
 
 You can either clone the entire `arkouda-contrib` repository or use sparse-checkout to only checkout the packages you will be using.
 
@@ -23,17 +23,17 @@ echo "<pkg_name>" >> .git/info/sparse-checkout
 git pull origin main
 ```
 
-##Install a Package
+## Install a Package
 
 Currently, `module_configuration.py` only supports installing a single package. If your package contains server elements, you will only be able to use a single package. Additional client-only modules could be installed. `module_configuration.py` will print the commands necessary to install a package. This output can be piped to `bash` to automatically execute the installation.
 
 <em>Note - Support for installing multiple modules is being tracked by [Issue #8](https://github.com/Bears-R-Us/arkouda-contrib/issues/8).</em>
 
-###Installation Parameters
+### Installation Parameters
 - `path` - this is the full path to the module you want to configure. This should be pathed to the top level folder containing the `client`, `server` and `test` directories.*REQUIRED*
 - `ak` - this is the full path to the Arkouda installation on your machine. *REQUIRED when module contains a server element only*.
 
-###Installation
+### Installation
 ```commandline
 # Dry Run - only prints commands
 python3 module_configuration.py --path <path to module> --ak <path to arkouda>


### PR DESCRIPTION
There were some instances where the md files were not formatted correctly, so this just adds some spaces so they render correctly when viewed on github.