### PR TITLE
Closes #40 - Upgrade to Python 3.8

### DIFF
--- a/akgraph/client/setup.py
+++ b/akgraph/client/setup.py
@@ -22,6 +22,6 @@ setup(
     install_requires=["h5py", "numpy"],
     python_requires=">=3.8",
     project_urls={
-        "Bug Reports": "https://github.com/Bears-R-Us/arkouda/issues",
+        "Bug Reports": "https://github.com/Bears-R-Us/arkouda-contrib/issues",
     },
 )

--- a/akgraph/client/setup.py
+++ b/akgraph/client/setup.py
@@ -1,27 +1,27 @@
-from setuptools import setup, find_packages
 from os import path
 
+from setuptools import find_packages, setup
 
 HERE = path.abspath(path.dirname(__file__))
-with open(path.join(HERE, 'README.md'), encoding='utf-8') as fh:
+with open(path.join(HERE, "README.md"), encoding="utf-8") as fh:
     LONG_DESCRIPTION = fh.read()
 
-setuptools.setup(
-    name='akgraph',
-    version='0.2.0',
+setup(
+    name="akgraph",
+    version="0.2.0",
     author="U.S. Government",
     author_email="",
     description="Graph algorithms in arkouda",
     long_description=LONG_DESCRIPTION,
     long_decription_content_type="text/markdown",
     keywords="HPC graph algorithm",
-    packages=setuptools.find_packages(),
+    packages=find_packages(),
     classifiers=["Programming Language :: Python :: 3"],
     use_scm_version=True,
-    setup_requires=['setuptools_scm'],
-    install_requires=['h5py','numpy'],
-    python_requires='>=3.6',
+    setup_requires=["setuptools_scm"],
+    install_requires=["h5py", "numpy"],
+    python_requires=">=3.8",
     project_urls={
-        'Bug Reports': 'https://github.com/Bears-R-Us/arkouda/issues',
-    }
+        "Bug Reports": "https://github.com/Bears-R-Us/arkouda/issues",
+    },
 )

--- a/aksolve/client/setup.py
+++ b/aksolve/client/setup.py
@@ -1,27 +1,26 @@
-from setuptools import setup, find_packages
 from os import path
 
+from setuptools import find_packages, setup
 
 HERE = path.abspath(path.dirname(__file__))
-with open(path.join(HERE, 'README.md'), encoding='utf-8') as fh:
+with open(path.join(HERE, "README.md"), encoding="utf-8") as fh:
     LONG_DESCRIPTION = fh.read()
 
 
-setuptools.setup(
-    name='aksolve',
-    version='0.0.0',
+setup(
+    name="aksolve",
+    version="0.0.0",
     author="U.S. Government",
     author_email="",
     description="Sparse linear equation solvers in arkouda",
     long_description=LONG_DESCRIPTION,
     long_decription_content_type="text/markdown",
     keywords="HPC linear equation solver arkouda iterative sparse",
-    packages=setuptools.find_packages(),
+    packages=find_packages(),
     classifiers=["Programming Language :: Python :: 3"],
     use_scm_version=True,
-    setup_requires=['setuptools_scm'],
-    install_requires=['numpy'],
-    python_requires='>=3.6',
-    project_urls={'Bug Reports':
-                  'https://github.com/Bears-R-Us/arkouda/issues'}
+    setup_requires=["setuptools_scm"],
+    install_requires=["numpy"],
+    python_requires=">=3.8",
+    project_urls={"Bug Reports": "https://github.com/Bears-R-Us/arkouda/issues"},
 )

--- a/aksparse/client/setup.py
+++ b/aksparse/client/setup.py
@@ -1,27 +1,26 @@
-from setuptools import setup, find_packages
 from os import path
+
+from setuptools import find_packages, setup
 
 here = path.abspath(path.dirname(__file__))
 
-with open(path.join(here, 'README.md'), encoding='utf-8') as fh:
+with open(path.join(here, "README.md"), encoding="utf-8") as fh:
     long_description = fh.read()
 
-setuptools.setup(
-        name='aksparse',
-        version='1.0.0',
-        author="U.S. Government",
-        author_email="",
-        description="Sparse matrix operations for arkouda",
-        long_description=long_description,
-        long_decription_content_type="text/markdown",
-        keywords="HPC exploratory analysis parallel distribute arrays Chapel sparse matrix linear",
-        packages=setuptools.find_packages(),
-        classifiers=[
-            "Programming Language :: Python :: 3"
-        ],
-        install_requires=['numpy', 'pandas', 'scipy'],
-        python_requires='>= 3.6',
-        project_urls={
-            'Bug Reports': 'https://github.com/Bear-R-Us/arkouda/issues',
-        }
+setup(
+    name="aksparse",
+    version="1.0.0",
+    author="U.S. Government",
+    author_email="",
+    description="Sparse matrix operations for arkouda",
+    long_description=long_description,
+    long_decription_content_type="text/markdown",
+    keywords="HPC exploratory analysis parallel distribute arrays Chapel sparse matrix linear",
+    packages=find_packages(),
+    classifiers=["Programming Language :: Python :: 3"],
+    install_requires=["numpy", "pandas", "scipy"],
+    python_requires=">= 3.8",
+    project_urls={
+        "Bug Reports": "https://github.com/Bear-R-Us/arkouda/issues",
+    },
 )

--- a/arkouda_BlockArrays2D/client/setup.py
+++ b/arkouda_BlockArrays2D/client/setup.py
@@ -1,20 +1,19 @@
-from setuptools import setup
 from os import path
+
+from setuptools import setup
 
 here = path.abspath(path.dirname(__file__))
 # Long description will be contents of README
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    name='arkouda_BlockArrays2D',
-    version='0.0.2',
-    description='2 dimensional Arkouda pdarrays.',
+    name="arkouda_BlockArrays2D",
+    version="0.0.2",
+    description="2 dimensional Arkouda pdarrays.",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    packages=['arkouda_BlockArrays2D'],
-    python_requires=">=3.7",
-    install_requires=[
-        'arkouda'
-    ]
+    long_description_content_type="text/markdown",
+    packages=["arkouda_BlockArrays2D"],
+    python_requires=">=3.8",
+    install_requires=["arkouda"],
 )

--- a/arkouda_distance/client/setup.py
+++ b/arkouda_distance/client/setup.py
@@ -1,20 +1,19 @@
-from setuptools import setup
 from os import path
+
+from setuptools import setup
 
 here = path.abspath(path.dirname(__file__))
 # Long description will be contents of README
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    name='arkouda_distance',
-    version='0.0.2',
-    description='Distance Computations for Arkouda pdarrays.',
+    name="arkouda_distance",
+    version="0.0.2",
+    description="Distance Computations for Arkouda pdarrays.",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    packages=['arkouda_distance'],
-    python_requires=">=3.7",
-    install_requires=[
-        'arkouda'
-    ]
+    long_description_content_type="text/markdown",
+    packages=["arkouda_distance"],
+    python_requires=">=3.8",
+    install_requires=["arkouda"],
 )

--- a/arkouda_distance_wserver/client/setup.py
+++ b/arkouda_distance_wserver/client/setup.py
@@ -1,21 +1,19 @@
-from setuptools import setup
 from os import path
+
+from setuptools import setup
 
 here = path.abspath(path.dirname(__file__))
 # Long description will be contents of README
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    name='arkouda_distance',
-    version='0.0.1',
-    description='Distance Computations for Arkouda pdarrays.',
+    name="arkouda_distance",
+    version="0.0.1",
+    description="Distance Computations for Arkouda pdarrays.",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    packages=['arkouda_distance'],
-    python_requires=">=3.7",
-    install_requires=[
-        'arkouda',
-        'typeguard'
-    ]
+    long_description_content_type="text/markdown",
+    packages=["arkouda_distance"],
+    python_requires=">=3.8",
+    install_requires=["arkouda", "typeguard"],
 )


### PR DESCRIPTION
Closes #40 

- Updates `setup.py` files for clients to require `python>=3.8`
- Ran `black` and `isort` to format.
- Updated `akgraph`, `aksparse`, and `aksolve` files to properly use elements imported from `setuptools`.