### PR TITLE
Add lisp code

### DIFF
--- a/aklisp/client/PlayAstWithArkouda.py
+++ b/aklisp/client/PlayAstWithArkouda.py
@@ -1,0 +1,54 @@
+
+import arkouda as ak
+
+from arkouda_lambda import arkouda_func
+
+# some test function definitions
+@arkouda_func
+def my_axpy(a : ak.float64, x : ak.pdarray, y : ak.pdarray) -> ak.pdarray:
+    return a * x + y
+
+@arkouda_func
+def my_filter(v : ak.int64, x : ak.pdarray, y : ak.pdarray) -> ak.pdarray:
+    return ((y+1) if (not (x < v)) else (y-1))
+
+@arkouda_func
+def my_filter2(v : ak.int64, x : ak.pdarray, y : ak.pdarray) -> ak.pdarray:
+    #(a := v*10)
+    return ((y+1) if (not (x < a)) else (y-1))
+
+@arkouda_func
+def my_filter3(v : ak.int64, x : ak.pdarray, y : ak.pdarray) -> ak.pdarray:
+    #(a := v*10)
+    return ((y+1) if (not (x < a) and (x >= 0)) else (y-1))
+
+# try it out
+ak.connect()
+x = ak.array([1.0,2,3,4,5,6,7,8,9,10])
+y = ak.array([10.0,10,10,10,10,10,10,10,10,10])
+a = 5.0
+
+#ret = my_axpy(5.0,x,y)
+
+ret = my_axpy(a,x,y).to_ndarray()
+print(ret)
+
+'''
+x = ak.randint(0,100,100, ak.float64)
+y = ak.randint(0,100,100, ak.float64)
+
+ret2 = my_axpy(a, x, y).to_ndarray()
+
+regCalc = (a*x+y).to_ndarray()
+for (val1, val2) in zip(ret2, regCalc):
+    if val1 != val2:
+        print("MISSED")
+        print(val1, val2)
+'''
+
+#ret = my_filter(5,x,y)
+
+#ret = my_filter2(5,x,y)
+
+#ret = my_filter3(5,x,y)
+

--- a/aklisp/client/__init__.py
+++ b/aklisp/client/__init__.py
@@ -1,0 +1,1 @@
+from .lisp import *

--- a/aklisp/client/lisp.py
+++ b/aklisp/client/lisp.py
@@ -1,0 +1,238 @@
+import json
+import inspect
+import ast
+
+import numpy as np
+
+from arkouda.client import generic_msg
+from arkouda.pdarrayclass import create_pdarray, pdarray
+from arkouda.dtypes import numeric_scalars
+
+
+class ArkoudaVisitor(ast.NodeVisitor):
+
+    # initialize return string which will contain scheme/lisp code
+    def __init__(self, annotations=None, args=None, echo=False):
+        self.name = ""
+        self.ret = ""
+        self.formal_arg = {}
+        self.echo = echo
+        self.annotations = annotations
+        self.args = args
+
+    # allowed nodes without specialized visitors
+    ALLOWED = tuple()
+    ALLOWED += (ast.Module,)
+    ALLOWED += (ast.Expr,)
+    
+    # Binary ops
+    ALLOWED += (ast.BinOp,)
+    def visit_BinOp(self, node):
+        self.ret += " ("
+        self.visit(node.op)
+        self.visit(node.left)
+        self.visit(node.right)
+        self.ret += " )"
+        if self.echo: print(self.ret)
+
+    ALLOWED += (ast.Add,)
+    def visit_Add(self, node):
+        self.ret += " +"
+
+    ALLOWED += (ast.Sub,)
+    def visit_Sub(self, node):
+        self.ret += " -"
+
+    ALLOWED += (ast.Mult,)
+    def visit_Mult(self, node):
+        self.ret += " *"
+        
+    # Comparison ops
+    ALLOWED += (ast.Compare,)
+    def visit_Compare(self, node):
+        if len(node.ops) != 1:
+            raise Exception("only one comparison operator allowed")
+        self.ret += " ("
+        self.visit(node.ops[0]) 
+        self.visit(node.left)  # left?
+        self.visit(node.comparators[0]) # right?
+        self.ret += " )"
+        if self.echo: print(self.ret)
+
+    ALLOWED += (ast.Eq,)
+    def visit_Eq(self, node):
+        self.ret += " =="
+
+    ALLOWED += (ast.NotEq,)
+    def visit_NotEq(self, node):
+        self.ret += " !="
+
+    ALLOWED += (ast.Lt,)
+    def visit_Lt(self, node):
+        self.ret += " <"
+
+    ALLOWED += (ast.LtE,)
+    def visit_LtE(self, node):
+        self.ret += " <="
+
+    ALLOWED += (ast.Gt,)
+    def visit_Gt(self, node):
+        self.ret += " >"
+
+    ALLOWED += (ast.GtE,)
+    def visit_GtE(self, node):
+        self.ret += " >="
+
+    # Boolean Ops
+    ALLOWED += (ast.BoolOp,)
+    def visit_BoolOp(self, node):
+        self.ret += " ("
+        self.visit(node.op)
+        for v in node.values:
+            self.visit(v)
+        self.ret += " )"
+        if self.echo: print(self.ret)
+
+    ALLOWED += (ast.And,)
+    def visit_And(self, node):
+        self.ret += " and"
+
+    ALLOWED += (ast.Or,)
+    def visit_Or(self, node):
+        self.ret += " or"
+
+    # Unary ops (only `not` at this point)
+    ALLOWED += (ast.UnaryOp,)
+    def visit_UnaryOp(self, node):
+        self.ret += " ("
+        self.visit(node.op) 
+        self.visit(node.operand)
+        self.ret += " )"
+        if self.echo: print(self.ret)
+
+    ALLOWED += (ast.Not,)
+    def visit_Not(self, node):
+        self.ret += " not"
+
+    # If Expression `(body) if (test) else (orelse)`
+    ALLOWED += (ast.IfExp,)
+    def visit_IfExp(self, node):
+        self.ret += " ( if"
+        self.visit(node.test)
+        self.visit(node.body)
+        self.visit(node.orelse)
+        self.ret += " )"
+        if self.echo: print(self.ret)
+
+    # Assignment which returns a value `(x := 5)`
+    ALLOWED += (ast.NamedExpr,)
+    def visit_NamedExpr(self, node):
+        self.ret += " ( :="
+        self.visit(node.target)
+        self.visit(node.value)
+        self.ret += " )"
+        if self.echo: print(self.ret)
+        
+    # Constant
+    ALLOWED += (ast.Constant,)
+    def visit_Constant(self, node):
+        self.ret += " " + str(node.value)
+        if self.echo: print(self.ret)
+
+    # Name, mostly variable names, I think
+    ALLOWED += (ast.Name,)
+    def visit_Name(self, node):
+        self.ret += " " + node.id
+        if self.echo: print(self.ret)
+        
+    # argument name in argument list
+    ALLOWED += (ast.arg,)
+    def visit_arg(self, node, i):
+        self.formal_arg[node.arg] = node.annotation.attr
+        if isinstance(self.args[i],pdarray): # need to have same size for all
+            self.ret += f" ( := {node.arg} ( lookup_and_index_{self.args[i].dtype} {self.args[i].name} i ) ) "
+        elif isinstance(self.args[i], numeric_scalars):
+            self.ret += " ( := " + node.arg + " " + str(self.args[i]) + " ) "
+        else:
+            raise Exception("unhandled arg type = " + str(self.args[i].type))
+        if self.echo: print(self.ret)
+        
+    # argument list
+    ALLOWED += (ast.arguments,)
+    def visit_arguments(self, node):
+        for (i, a) in enumerate(node.args):
+            self.visit_arg(a, i)
+        if self.echo: print(self.ret)
+
+    # Return, `return value`
+    ALLOWED += (ast.Return,)
+    def visit_Return(self, node):
+        self.ret += " ( return"
+        self.visit(node.value)
+        self.ret += " )"
+        if self.echo: print(self.ret)
+
+    # Function Definition
+    ALLOWED += (ast.FunctionDef,)
+    def visit_FunctionDef(self, node):
+        self.name = node.name
+        self.ret += "( begin"
+        self.visit_arguments(node.args)
+        for b in node.body:
+            self.visit(b)
+        self.ret += " )"
+        if self.echo: print(self.ret)
+
+    # override ast.NodeVisitor.visit() method
+    def visit(self, node):
+        """Ensure only contains allowed ast nodes."""
+        if not isinstance(node, self.ALLOWED):
+            raise SyntaxError("ast node not allowed: " + str(node))
+        ast.NodeVisitor.visit(self, node)
+
+
+
+# Arkouda function decorator
+# transforms a simple python function into a Scheme/Lisp lambda
+# which could be sent to the arkouda server to be evaluated there
+def arkouda_func(func):
+    def wrapper(*args):
+        num_elems = -1
+        elem_dtypes = []
+        for arg in args:
+            if isinstance(arg, pdarray):
+                elem_dtypes.append(arg.dtype)
+                if num_elems == -1:
+                    num_elems = arg.size
+                else:
+                    if arg.size != num_elems:
+                        raise Exception("size mismatch exception; all pdarrays must be same size")
+            else:
+                elem_dtypes.append(type(arg).__name__)
+
+        ret_type = "float64" if (elem_dtypes.count("float") + elem_dtypes.count("float64")) > 0 else "int64"
+                
+         # get source code for function
+        source_code = inspect.getsource(func)
+        # print("source_code :\n" + source_code)
+
+         # parse sorce code into a python ast
+        tree = ast.parse(source_code)
+        #print(ast.dump(tree, indent=4))
+
+         # create ast visitor to transform ast into scheme/lisp code
+        visitor = ArkoudaVisitor(annotations=func.__annotations__, args=args, echo=False)
+        visitor.visit(tree)
+
+        # construct a message to the arkouda server
+        # send it
+        # get result
+        # return pdarray of result
+        repMsg = generic_msg(cmd="lispCode", args=f"{ret_type} | {num_elems} | {visitor.ret}")
+        
+        # return a dummy pdarray
+        return create_pdarray(repMsg)
+        
+    return wrapper
+
+

--- a/aklisp/client/setup.py
+++ b/aklisp/client/setup.py
@@ -1,0 +1,19 @@
+from os import path
+
+from setuptools import setup
+
+here = path.abspath(path.dirname(__file__))
+# Long description will be contents of README
+with open(path.join(here, "README.md"), encoding="utf-8") as f:
+    long_description = f.read()
+
+setup(
+    name="aklisp",
+    version="0.0.1",
+    description="Lisp expression computation",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    packages=["aklisp"],
+    python_requires=">=3.10",
+    install_requires=["arkouda", "typeguard"],
+)

--- a/aklisp/pytest.ini
+++ b/aklisp/pytest.ini
@@ -1,0 +1,14 @@
+[pytest]
+filterwarnings =
+    ignore:Version mismatch between client .*
+testpaths =
+    test/lisp_test.py
+python_functions = test*
+env =
+    D:ARKOUDA_SERVER_HOST=localhost
+    D:ARKOUDA_SERVER_PORT=5555
+    D:ARKOUDA_RUNNING_MODE=CLASS_SERVER
+    D:ARKOUDA_NUMLOCALES=2
+    D:ARKOUDA_VERBOSE=True
+    D:ARKOUDA_CLIENT_TIMEOUT=0
+    D:ARKOUDA_LOG_LEVEL=DEBUG

--- a/aklisp/server/LisExprData.chpl
+++ b/aklisp/server/LisExprData.chpl
@@ -1,0 +1,293 @@
+module LisExprData
+{
+
+    public use List;
+    public use Map;
+    
+    type Symbol = string;
+
+   /* allowed list value types */
+    enum LVT {Lst, Sym, I, R};
+    
+    /* allowed value types in the eval */
+    /* in a real scheme/lisp interpreter these two enums (LVT and VT) would be the same */
+    enum VT {I, R};
+
+    /* type: generic list values */
+    type GenListValue = shared GenListValueClass;
+    type BGenListValue = borrowed GenListValueClass;
+    type ListValue = shared ListValueClass;
+    type BListValue = borrowed ListValueClass;
+    
+    /* type: list of generic list values */
+    type GenList = shared ListClass(GenListValue);
+    type BGenlist = borrowed ListClass(GenListValue);
+    
+    /* type: generic values for eval */
+    type GenValue = owned GenValueClass;
+    type BGenValue = borrowed GenValueClass;
+    type Value = owned ValueClass;
+    type BValue = borrowed ValueClass;
+
+    /*
+      List Class wraps the standard List which is a record
+      forwarding the interface to the class definition
+      this gives me a more familiar feel to lists in python
+    */
+    class ListClass {
+      type etype;
+      forwarding var l: list(etype);
+    }
+    
+    /* generic list value class def */
+    class GenListValueClass
+    {
+        var lvt: LVT;
+        
+        /* initialize the list value type so we can test it at runtime */
+        proc init(type lvtype) {
+            if (lvtype == GenList)            {lvt = LVT.Lst;}
+            if (lvtype == Symbol)             {lvt = LVT.Sym;}
+            if (lvtype == int)                {lvt = LVT.I;}
+            if (lvtype == real)               {lvt = LVT.R;}
+        }
+        
+        /* cast to the GenListValue to borrowed ListValue(vtype) halt on failure */
+        inline proc toListValue(type lvtype) {
+            return try! this :BListValue(lvtype);
+        }
+
+        /* returns a copy of this... an owned GenListValue */
+        proc copy(): GenListValue throws {
+          select (this.lvt) {
+            when (LVT.Lst) {
+              return new ListValue(this.toListValue(GenList).lv);
+            }
+            when (LVT.Sym) {
+              return new ListValue(this.toListValue(Symbol).lv);
+            }
+            when (LVT.I) {
+              return new ListValue(this.toListValue(int).lv);
+            }
+            when (LVT.R) {
+              return new ListValue(this.toListValue(real).lv);
+            }
+            otherwise {throw new owned Error("not implemented");}
+          }
+        }
+    }
+    
+    /* concrete list value class def */
+    class ListValueClass : GenListValueClass
+    {
+        type lvtype;
+        var lv: lvtype;
+        
+        /* initialize the value and the vtype */
+        proc init(val: ?vtype) {
+            super.init(vtype);
+            this.lvtype = vtype;
+            this.lv = val;
+            this.complete();
+        }
+        
+    }
+
+    
+    /* generic value class */
+    class GenValueClass
+    {
+        /* value type testable at runtime */
+        var vt: VT;
+    
+        /* initialize the value type so we can test it at runtime */
+        proc init(type vtype) {
+            if (vtype == int)  {vt = VT.I;}
+            if (vtype == real) {vt = VT.R;}
+        }
+        
+        /* cast to the GenValue to borrowed Value(vtype) halt on failure */
+        inline proc toValue(type vtype) {
+            return try! this :BValue(vtype);
+        }
+
+        /* returns a copy of this... an owned GenValue */
+        proc copy(): GenValue throws {
+            select (this.vt) {
+                when (VT.I) {return new Value(this.toValue(int).v);}
+                when (VT.R) {return new Value(this.toValue(real).v);}
+                otherwise { throw new owned Error("not implemented"); }
+            }
+        }
+    }
+    
+    /* concrete value class */
+    class ValueClass : GenValueClass
+    {
+        type vtype; // value type
+        var v: vtype; // value
+        
+        /* initialize the value and the vtype */
+        proc init(val: ?vtype) {
+            super.init(vtype);
+            this.vtype = vtype;
+            this.v = val;
+        }
+    }
+
+    //////////////////////////////////////////
+    // operators over GenValue
+    //////////////////////////////////////////
+    
+    inline operator +(l: BGenValue, r: BGenValue): GenValue throws {
+        select (l.vt, r.vt) {
+            when (VT.I, VT.I) {return new Value(l.toValue(int).v + r.toValue(int).v);}
+            when (VT.I, VT.R) {return new Value(l.toValue(int).v + r.toValue(real).v);}
+            when (VT.R, VT.I) {return new Value(l.toValue(real).v + r.toValue(int).v);}
+            when (VT.R, VT.R) {return new Value(l.toValue(real).v + r.toValue(real).v);}
+            otherwise {throw new owned Error("not implemented");}
+        }
+    }
+
+    inline operator -(l: BGenValue, r: BGenValue): GenValue throws {
+        select (l.vt, r.vt) {
+            when (VT.I, VT.I) {return new Value(l.toValue(int).v - r.toValue(int).v);}
+            when (VT.I, VT.R) {return new Value(l.toValue(int).v - r.toValue(real).v);}
+            when (VT.R, VT.I) {return new Value(l.toValue(real).v - r.toValue(int).v);}
+            when (VT.R, VT.R) {return new Value(l.toValue(real).v - r.toValue(real).v);}
+            otherwise {throw new owned Error("not implemented");}
+        }
+    }
+
+    inline operator *(l: BGenValue, r: BGenValue): GenValue throws {
+        select (l.vt, r.vt) {
+            when (VT.I, VT.I) {return new Value(l.toValue(int).v * r.toValue(int).v);}
+            when (VT.I, VT.R) {return new Value(l.toValue(int).v * r.toValue(real).v);}
+            when (VT.R, VT.I) {return new Value(l.toValue(real).v * r.toValue(int).v);}
+            when (VT.R, VT.R) {return new Value(l.toValue(real).v * r.toValue(real).v);}
+            otherwise {throw new owned Error("not implemented");}
+        }
+    }
+
+    inline operator <(l: BGenValue, r: BGenValue): GenValue throws {
+        select (l.vt, r.vt) {
+            when (VT.I, VT.I) {return new Value((l.toValue(int).v < r.toValue(int).v):int);}
+            when (VT.I, VT.R) {return new Value((l.toValue(int).v < r.toValue(real).v):int);}
+            when (VT.R, VT.I) {return new Value((l.toValue(real).v < r.toValue(int).v):int);}
+            when (VT.R, VT.R) {return new Value((l.toValue(real).v < r.toValue(real).v):int);}
+            otherwise {throw new owned Error("not implemented");}
+        }
+    }
+
+    inline operator >(l: BGenValue, r: BGenValue): GenValue throws {
+        select (l.vt, r.vt) {
+            when (VT.I, VT.I) {return new Value((l.toValue(int).v > r.toValue(int).v):int);}
+            when (VT.I, VT.R) {return new Value((l.toValue(int).v > r.toValue(real).v):int);}
+            when (VT.R, VT.I) {return new Value((l.toValue(real).v > r.toValue(int).v):int);}
+            when (VT.R, VT.R) {return new Value((l.toValue(real).v > r.toValue(real).v):int);}
+            otherwise {throw new owned Error("not implemented");}
+        }
+    }
+
+    inline operator <=(l: BGenValue, r: BGenValue): GenValue throws {
+        select (l.vt, r.vt) {
+            when (VT.I, VT.I) {return new Value((l.toValue(int).v <= r.toValue(int).v):int);}
+            when (VT.I, VT.R) {return new Value((l.toValue(int).v <= r.toValue(real).v):int);}
+            when (VT.R, VT.I) {return new Value((l.toValue(real).v <= r.toValue(int).v):int);}
+            when (VT.R, VT.R) {return new Value((l.toValue(real).v <= r.toValue(real).v):int);}
+            otherwise {throw new owned Error("not implemented");}
+        }
+    }
+
+    inline operator >=(l: BGenValue, r: BGenValue): GenValue throws {
+        select (l.vt, r.vt) {
+            when (VT.I, VT.I) {return new Value((l.toValue(int).v >= r.toValue(int).v):int);}
+            when (VT.I, VT.R) {return new Value((l.toValue(int).v >= r.toValue(real).v):int);}
+            when (VT.R, VT.I) {return new Value((l.toValue(real).v >= r.toValue(int).v):int);}
+            when (VT.R, VT.R) {return new Value((l.toValue(real).v >= r.toValue(real).v):int);}
+            otherwise {throw new owned Error("not implemented");}
+        }
+    }
+
+    inline operator ==(l: BGenValue, r: BGenValue): GenValue throws {
+        select (l.vt, r.vt) {
+            when (VT.I, VT.I) {return new Value((l.toValue(int).v == r.toValue(int).v):int);}
+            when (VT.I, VT.R) {return new Value((l.toValue(int).v == r.toValue(real).v):int);}
+            when (VT.R, VT.I) {return new Value((l.toValue(real).v == r.toValue(int).v):int);}
+            when (VT.R, VT.R) {return new Value((l.toValue(real).v == r.toValue(real).v):int);}
+            otherwise {throw new owned Error("not implemented");}
+        }
+    }
+
+    inline operator !=(l: BGenValue, r: BGenValue): GenValue throws {
+        select (l.vt, r.vt) {
+            when (VT.I, VT.I) {return new Value((l.toValue(int).v != r.toValue(int).v):int);}
+            when (VT.I, VT.R) {return new Value((l.toValue(int).v != r.toValue(real).v):int);}
+            when (VT.R, VT.I) {return new Value((l.toValue(real).v != r.toValue(int).v):int);}
+            when (VT.R, VT.R) {return new Value((l.toValue(real).v != r.toValue(real).v):int);}
+            otherwise {throw new owned Error("not implemented");}
+        }
+    }
+
+    inline proc and(l: BGenValue, r: BGenValue): GenValue throws {
+        return new Value((l && r):int);
+    }
+
+    inline proc or(l: BGenValue, r: BGenValue): GenValue throws {
+        return new Value((l || r):int);
+    }
+
+    inline proc not(l: BGenValue): GenValue throws {
+        return new Value((! isTrue(l)):int);
+    }
+
+    inline proc isTrue(gv: BGenValue): bool throws {
+        select (gv.vt) {
+            when (VT.I) {return (gv.toValue(int).v != 0);}
+            when (VT.R) {return (gv.toValue(real).v != 0.0);}
+            otherwise {throw new owned Error("not implemented");}
+        }
+    }
+    
+    /* environment is a dictionary of {string:GenValue} */
+    class Env
+    {
+        /* map of Symbol to GenValue */
+        var tab: map(Symbol, GenValue);
+
+        /* add a new entry or set an entry to a new value */
+        proc addEntry(name:string, val: ?t): BValue(t) throws {
+            var entry = new Value(val);
+            tab.addOrSet(name, entry);
+            return tab.getBorrowed(name).toValue(t);
+        }
+
+        /* add a new entry or set an entry to a new value */
+        proc addEntry(name:string, in entry: GenValue): BGenValue throws {
+            tab.addOrSet(name, entry);
+            return tab.getBorrowed(name);
+        }
+
+        /* lookup symbol and throw error if not found */
+        proc lookup(name: string): BGenValue throws {
+            if (!tab.contains(name)) {
+              throw new owned Error("undefined symbol error " + name);
+            }
+            return tab.getBorrowed(name);
+        }
+
+        /* delete entry -- not sure if we need this */
+        proc deleteEntry(name: string) {
+            import IO.stdout;
+            if (tab.contains(name)) {
+                tab.remove(name);
+            }
+            else {
+                writeln("unkown symbol ",name);
+                try! stdout.flush();
+            }
+        }
+    }
+
+
+}

--- a/aklisp/server/LisExprInterp.chpl
+++ b/aklisp/server/LisExprInterp.chpl
@@ -1,0 +1,177 @@
+module LisExprInterp
+{
+
+    use LisExprData;
+
+    /*
+      tokenize the prog
+    */
+    proc tokenize(line: string) {
+        var l: list(string) = line.replace("("," ( ").replace(")"," ) ").split();
+        return l;
+    }
+    
+    /*
+      parse, check, and validate code and all symbols in the tokenized prog
+    */ 
+    proc parse(line: string): GenListValue throws {
+        // Want:
+        //   return read_from_tokens(tokenize(line));
+        //
+        // Workaround (see https://github.com/chapel-lang/chapel/issues/16170):
+
+        var l: list(string) = tokenize(line);
+        return read_from_tokens(l);
+    }
+    
+    /*
+      parse throught the list of tokens generating the parse tree / AST
+      as a list of atoms and lists
+    */
+    proc read_from_tokens(ref tokens: list(string)): GenListValue throws {
+        if (tokens.size == 0) then
+            throw new owned Error("SyntaxError: unexpected EOF");
+
+        // Open Q: If we were to parse from the back of the string to the
+        // front, could this be more efficient since popping from the
+        // front of a list is an expensive operation?
+
+        var token = tokens.pop(0);
+        if (token == "(") {
+            var L = new GenList();
+            while (tokens.first() != ")") {
+                L.append(read_from_tokens(tokens));
+                if (tokens.size == 0) then
+                    throw new owned Error("SyntaxError: unexpected EOF");
+            }
+            tokens.pop(0); // pop off ")"
+            return new ListValue(L);
+        }
+        else if (token == ")") {
+            throw new owned Error("SyntaxError: unexpected )");
+        }
+        else {
+            return atom(token);
+        }
+    }
+    
+    /* determine atom type and values */
+    proc atom(token: string): GenListValue {
+        try { // try to interpret as an integer ?
+            return new ListValue(token:int); 
+        } catch {
+            try { //try to interpret it as a real ?
+                return new ListValue(token:real);
+            } catch { // return it as a symbol
+                return new ListValue(token);
+            }
+        }
+    }
+    
+    /* check to see if list value is a symbol otherwise throw error */
+    inline proc checkSymbol(arg: BGenListValue) throws {
+        if (arg.lvt != LVT.Sym) {
+          throw new owned Error("arg must be a symbol " + arg:string);
+        }
+    }
+
+    /* check to see if size is greater than or equal to size otherwise throw error */
+    inline proc checkGEqLstSize(lst: GenList, sz: int) throws {
+        if (lst.size < sz) {
+          throw new owned Error("list must be at least size " + sz:string + " " + lst:string);
+        }
+    }
+
+    /* check to see if size is equal to size otherwise throw error */
+    inline proc checkEqLstSize(lst: GenList, sz: int) throws {
+        if (lst.size != sz) {
+          throw new owned Error("list must be size" + sz:string + " " +  lst:string);
+        }
+    }
+
+    /*
+      evaluate the expression
+    */
+    proc eval(ast: BGenListValue, env: borrowed Env, st): GenValue throws {
+        select (ast.lvt) {
+            when (LVT.Sym) {
+                var gv = env.lookup(ast.toListValue(Symbol).lv);
+                return gv.copy();
+            }
+            when (LVT.I) {
+                var ret: int = ast.toListValue(int).lv;
+                return new Value(ret);
+            }
+            when (LVT.R) {
+                var ret: real = ast.toListValue(real).lv;
+                return new Value(ret);
+            }
+            when (LVT.Lst) {
+                ref lst = ast.toListValue(GenList).lv;
+                // no empty lists allowed
+                checkGEqLstSize(lst,1);
+                // currently first list element must be a symbol of operator
+                checkSymbol(lst[0]);
+                var op = lst[0].toListValue(Symbol).lv;
+                select (op) {
+                    when "+"   {checkEqLstSize(lst,3); return eval(lst[1], env, st) + eval(lst[2], env, st);}
+                    when "-"   {checkEqLstSize(lst,3); return eval(lst[1], env, st) - eval(lst[2], env, st);}
+                    when "*"   {checkEqLstSize(lst,3); return eval(lst[1], env, st) * eval(lst[2], env, st);}
+                    when "=="  {checkEqLstSize(lst,3); return eval(lst[1], env, st) == eval(lst[2], env, st);}
+                    when "!="  {checkEqLstSize(lst,3); return eval(lst[1], env, st) != eval(lst[2], env, st);}
+                    when "<"   {checkEqLstSize(lst,3); return eval(lst[1], env, st) < eval(lst[2], env, st);}
+                    when "<="  {checkEqLstSize(lst,3); return eval(lst[1], env, st) <= eval(lst[2], env, st);}
+                    when ">"   {checkEqLstSize(lst,3); return eval(lst[1], env, st) > eval(lst[2], env, st);}
+                    when ">="  {checkEqLstSize(lst,3); return eval(lst[1], env, st) >= eval(lst[2], env, st);}
+                    when "or"  {checkEqLstSize(lst,3); return or(eval(lst[1], env, st), eval(lst[2], env, st));}
+                    when "and" {checkEqLstSize(lst,3); return and(eval(lst[1], env, st), eval(lst[2], env, st));}
+                    when "not" {checkEqLstSize(lst,2); return not(eval(lst[1], env, st));}
+                    when ":=" {
+                        checkEqLstSize(lst,3);
+                        checkSymbol(lst[1]);
+                        var name = lst[1].toListValue(Symbol).lv;
+                        // addEnrtry redefines values for already existing entries
+                        var gv = env.addEntry(name, eval(lst[2],env, st));
+                        //TODO: how to continue evaling after an assignment?
+                        return gv.copy(); // return value assigned to symbol
+                    }
+                    when "lookup_and_index_float64" {
+                        var entry = st.lookup(lst[1].toListValue(Symbol).lv);
+                        var e = toSymEntry(toGenSymEntry(entry), real);
+                        var i = eval(lst[2],env,st).toValue(int).v;
+                        return new Value(e.a[i]);
+                    }
+                    when "lookup_and_index_int64" {
+                        var entry = st.lookup(lst[1].toListValue(Symbol).lv);
+                        var e = toSymEntry(toGenSymEntry(entry), int);
+                        var i = eval(lst[2],env,st).toValue(int).v;
+                        return new Value(e.a[i]);
+                    }
+                    when "if" {
+                        checkEqLstSize(lst,4);
+                        if isTrue(eval(lst[1], env, st)) {return eval(lst[2], env, st);} else {return eval(lst[3], env, st);}
+                    }
+                    when "begin" {
+                      checkGEqLstSize(lst, 1);
+                      // setup the environment
+                      for i in 1..#lst.size-1 do
+                        eval(lst[i], env, st);
+                      // eval the return expression
+                      return eval(lst[lst.size-1], env, st);
+                    }
+                    when "return" { // for now, just eval the next line, in time, might want to coerce return value
+                        return eval(lst[1], env, st);
+                    }
+                    otherwise {
+                        throw new owned Error("op not implemented " + op);
+                    }
+                }
+            }
+            otherwise {
+              throw new owned Error("undefined ast node type " + ast:string);
+            }
+        }
+    }
+
+
+}

--- a/aklisp/server/LispMsg.chpl
+++ b/aklisp/server/LispMsg.chpl
@@ -1,0 +1,116 @@
+/* Processing of Arkouda lambda functions
+   This allows users to write simple operations
+   involving pdarrays and scalars to be computed
+   in a single operation on the server side. This
+   works by parsing the code, converting it to an
+   AST, generating lisp code, then executing that
+   lisp code on the server.
+ */
+
+module LispMsg
+{
+    use ServerConfig;
+
+    use Time only;
+    use Math only;
+    use Reflection only;
+
+    use MultiTypeSymbolTable;
+    use MultiTypeSymEntry;
+    use SegmentedString;
+    use ServerErrorStrings;
+
+    use Reflection;
+    use ServerErrors;
+    use Logging;
+    use Message;
+
+    use LisExprData;
+    use LisExprInterp;
+
+    use GenSymIO;
+    use Message;
+
+    private config const logLevel = ServerConfig.logLevel;
+    const asLogger = new Logger(logLevel);
+
+    const numTasks = here.maxTaskPar;
+    const Tasks = {0..#numTasks}; // these need to be const for comms/performance reasons
+
+    // calculate sub-domain for task
+    inline proc calcBlock(task: int, low: int, high: int) {
+      var totalsize = high - low + 1;
+      var div = totalsize / numTasks;
+      var rem = totalsize % numTasks;
+      var rlow: int;
+      var rhigh: int;
+      if (task < rem) {
+        rlow = task * (div+1) + low;
+        rhigh = rlow + div;
+      }
+      else {
+        rlow = task * div + rem + low;
+        rhigh = rlow + div - 1;
+      }
+      return {rlow .. rhigh};
+    }
+    /*
+    Parse, execute, and respond to a setdiff1d message
+    :arg reqMsg: request containing (cmd,name,name2,assume_unique)
+    :type reqMsg: string
+    :arg st: SymTab to act on
+    :type st: borrowed SymTab
+    :returns: (MsgTuple) response message
+    */
+    proc lispMsg(cmd: string, payload: string, st: borrowed SymTab): MsgTuple throws {
+        param pn = Reflection.getRoutineName();
+        var repMsg: string; // response message
+        // TODO: If we support `|` in lisp, we don't want that to be delimeter
+        var (retTypeStr, sizeStr, lispCode) = payload.splitMsgToTuple("|", 3);
+
+        writeln("Ret type: ", retTypeStr);
+        writeln("Size: ", sizeStr);
+        writeln("Lisp code: ", lispCode);
+
+        retTypeStr = retTypeStr.strip(" ");
+        
+        var size = sizeStr: int;
+
+        var retName = st.nextName();
+
+        if retTypeStr == "int64" {
+          var ret = st.addEntry(retName, size, int);
+          evalLisp(lispCode, ret.a, st);
+        } else if retTypeStr == "float64" {
+          var ret = st.addEntry(retName, size, real);
+          evalLisp(lispCode, ret.a, st);
+        }
+        repMsg = "created " + st.attrib(retName);
+        return new MsgTuple(repMsg, MsgType.NORMAL);
+    }
+    
+    proc evalLisp(prog: string, ret: [] ?t, st) throws {
+      try {
+        coforall loc in Locales {
+            on loc {
+                coforall task in Tasks {
+                    var lD = ret.domain.localSubdomain();
+                    var tD = calcBlock(task, lD.low, lD.high);
+                    var ast = parse(prog);
+                    for i in tD {
+                        var env = new owned Env();
+                        env.addEntry("i", i);
+                        
+                        // Evaluate for this index
+                        ret[i] = eval(ast, env, st).toValue(t).v;
+                    }
+                }
+            }
+        }
+      } catch e {
+        writeln(e!.message());
+      }
+    }
+    use CommandMap;
+    registerFunction("lispCode", lispMsg, getModuleName());
+}

--- a/aklisp/server/ServerModules.cfg
+++ b/aklisp/server/ServerModules.cfg
@@ -1,0 +1,1 @@
+LispMsg

--- a/aklisp/test/lisp-stream.py
+++ b/aklisp/test/lisp-stream.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+
+import argparse
+import time
+
+import numpy as np
+
+import arkouda as ak
+from arkouda import arkouda_func
+
+TYPES = ("int64", "float64")
+
+
+def time_ak_stream(N_per_locale, trials, alpha, dtype, random, seed):
+    print(">>> arkouda {} stream".format(dtype))
+    cfg = ak.get_config()
+    N = N_per_locale * cfg["numLocales"]
+    print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
+    if random or seed is not None:
+        if dtype == "int64":
+            a = ak.randint(0, 2**32, N, seed=seed)
+            b = ak.randint(0, 2**32, N, seed=seed)
+        elif dtype == "float64":
+            a = ak.randint(0, 1, N, dtype=ak.float64, seed=seed)
+            b = ak.randint(0, 1, N, dtype=ak.float64, seed=seed)
+    else:
+        a = ak.ones(N, dtype=dtype)
+        b = ak.ones(N, dtype=dtype)
+
+    timings = []
+    for i in range(trials):
+        start = time.time()
+        c = a + b * alpha
+        end = time.time()
+        timings.append(end - start)
+    tavg = sum(timings) / trials
+
+    print("Average time = {:.4f} sec".format(tavg))
+    bytes_per_sec = (c.size * c.itemsize * 3) / tavg
+    print("Average rate = {:.2f} GiB/sec".format(bytes_per_sec / 2**30))
+
+@arkouda_func
+def my_axpy(a: ak.float64, x : ak.pdarray, y: ak.pdarray) -> ak.pdarray:
+    return a * x + y
+    
+def time_lisp_stream(N_per_locale, trials, alpha, dtype, random, seed):
+    print(">>> arkouda {} lisp stream".format(dtype))
+    cfg = ak.get_config()
+    N = N_per_locale * cfg["numLocales"]
+    print("numLocales = {}, N = {:,}".format(cfg["numLocales"], N))
+    if random or seed is not None:
+        if dtype == "int64":
+            a = ak.randint(0, 2**32, N, seed=seed)
+            b = ak.randint(0, 2**32, N, seed=seed)
+        elif dtype == "float64":
+            a = ak.randint(0, 1, N, dtype=ak.float64, seed=seed)
+            b = ak.randint(0, 1, N, dtype=ak.float64, seed=seed)
+    else:
+        a = ak.ones(N, dtype=dtype)
+        b = ak.ones(N, dtype=dtype)
+
+    timings = []
+    for i in range(trials):
+        start = time.time()
+        c = my_axpy(alpha, a, b)
+        end = time.time()
+        timings.append(end - start)
+    tavg = sum(timings) / trials
+
+    print("Average time = {:.4f} sec".format(tavg))
+    bytes_per_sec = (c.size * c.itemsize * 3) / tavg
+    print("Average rate = {:.2f} GiB/sec".format(bytes_per_sec / 2**30))
+
+def time_np_stream(N, trials, alpha, dtype, random, seed):
+    print(">>> numpy {} stream".format(dtype))
+    print("N = {:,}".format(N))
+    if seed is not None:
+        np.random.seed(seed)
+    if random or seed is not None:
+        if dtype == "int64":
+            a = np.random.randint(0, 2**32, N)
+            b = np.random.randint(0, 2**32, N)
+        elif dtype == "float64":
+            a = np.random.random(N)
+            b = np.random.random(N)
+    else:
+        a = np.ones(N, dtype=dtype)
+        b = np.ones(N, dtype=dtype)
+
+    timings = []
+    for i in range(trials):
+        start = time.time()
+        c = a + b * alpha
+        end = time.time()
+        timings.append(end - start)
+    tavg = sum(timings) / trials
+
+    print("Average time = {:.4f} sec".format(tavg))
+    bytes_per_sec = (c.size * c.itemsize * 3) / tavg
+    print("Average rate = {:.2f} GiB/sec".format(bytes_per_sec / 2**30))
+
+
+def check_correctness(alpha, dtype, random, seed):
+    N = 10**4
+    if seed is not None:
+        np.random.seed(seed)
+    if random or seed is not None:
+        if dtype == "int64":
+            a = np.random.randint(0, 2**32, N)
+            b = np.random.randint(0, 2**32, N)
+        elif dtype == "float64":
+            a = np.random.random(N)
+            b = np.random.random(N)
+    else:
+        a = np.ones(N, dtype=dtype)
+        b = np.ones(N, dtype=dtype)
+    npc = a + b * alpha
+    akc = ak.array(a) + ak.array(b) * alpha
+    assert np.allclose(npc, akc.to_ndarray())
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Run the stream benchmark: C = A + alpha*B")
+    parser.add_argument("hostname", help="Hostname of arkouda server")
+    parser.add_argument("port", type=int, help="Port of arkouda server")
+    parser.add_argument(
+        "-n", "--size", type=int, default=10**8, help="Problem size: length of arrays A and B"
+    )
+    parser.add_argument(
+        "-t", "--trials", type=int, default=6, help="Number of times to run the benchmark"
+    )
+    parser.add_argument(
+        "-d", "--dtype", default="float64", help="Dtype of arrays ({})".format(", ".join(TYPES))
+    )
+    parser.add_argument(
+        "-r",
+        "--randomize",
+        default=False,
+        action="store_true",
+        help="Fill arrays with random values instead of ones",
+    )
+    parser.add_argument("-a", "--alpha", default=1.0, help="Scalar multiple")
+    parser.add_argument(
+        "--numpy",
+        default=False,
+        action="store_true",
+        help="Run the same operation in NumPy to compare performance.",
+    )
+    parser.add_argument(
+        "--lisp",
+        default=False,
+        action="store_true",
+        help="Run the same operation using Arkouda lambda to compare performance.",
+    )
+    parser.add_argument(
+        "--correctness-only",
+        default=False,
+        action="store_true",
+        help="Only check correctness, not performance.",
+    )
+    parser.add_argument(
+        "-s", "--seed", default=None, type=int, help="Value to initialize random number generator"
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    import sys
+
+    parser = create_parser()
+    args = parser.parse_args()
+    if args.dtype not in TYPES:
+        raise ValueError("Dtype must be {}, not {}".format("/".join(TYPES), args.dtype))
+    args.alpha = getattr(ak, args.dtype).type(args.alpha)
+    ak.verbose = False
+    ak.connect(server=args.hostname, port=args.port)
+
+    if args.correctness_only:
+        for dtype in TYPES:
+            alpha = getattr(ak, dtype).type(args.alpha)
+            check_correctness(alpha, dtype, args.randomize, args.seed)
+        sys.exit(0)
+
+    print("array size = {:,}".format(args.size))
+    print("number of trials = ", args.trials)
+    time_ak_stream(args.size, args.trials, args.alpha, args.dtype, args.randomize, args.seed)
+    if args.numpy:
+        time_np_stream(args.size, args.trials, args.alpha, args.dtype, args.randomize, args.seed)
+        print("Verifying agreement between arkouda and NumPy on small problem... ", end="")
+        check_correctness(args.alpha, args.dtype, args.randomize, args.seed)
+        print("CORRECT")
+    if args.lisp:
+        time_lisp_stream(args.size, args.trials, args.alpha, args.dtype, args.randomize, args.seed)
+
+    sys.exit(0)

--- a/aklisp/test/lisp_test.py
+++ b/aklisp/test/lisp_test.py
@@ -1,0 +1,18 @@
+import numpy as np
+from base_test import ArkoudaTest
+import arkouda as ak
+
+@arkouda_func
+def my_axpy(a: ak.float64, x : ak.pdarray, y: ak.pdarray) -> ak.pdarray:
+    return a * x + y
+
+class LispTest(ArkoudaTest):
+    def test_my_axpy(self):
+        a = 5.0
+        x = ak.randint(0,100,100,np.float64)
+        y = ak.randint(0,100,100,np.float64)
+
+        lisp_res = my_axpy(a,x,y)
+        ak_res = a * x + y
+
+        self.assertTrue((lisp_res == ak_res).all())


### PR DESCRIPTION
This PR adds lisp code that enables to usage of an `arkouda_func` annotation that will convert the contents of the function into lisp code to send to the server in a single message containing the lisp code and then execute that on the server.