### PR TITLE
update BlockArrays2D to use JSON message arguments

### DIFF
--- a/arkouda_BlockArrays2D/pytest.ini
+++ b/arkouda_BlockArrays2D/pytest.ini
@@ -2,7 +2,7 @@
 filterwarnings =
     ignore:Version mismatch between client .*
 testpaths =
-    test/multdimarrays_test.py
+    test/BlockArrays2D_test.py
 norecursedirs = .git dist build *egg* tests/deprecated/*
 python_functions = test*
 env =

--- a/arkouda_BlockArrays2D/test/BlockArrays2D_test.py
+++ b/arkouda_BlockArrays2D/test/BlockArrays2D_test.py
@@ -3,6 +3,14 @@ import arkouda as ak
 import arkouda_BlockArrays2D as ak2D
 
 class Array2DTest(ArkoudaTest):
+    def test_create(self):
+        a2di = ak2D.array2D(0, 2, 2, dtype=ak.int64)
+        self.assertTrue((a2di[0] == ak.array([0,0], dtype=ak.int64)).all())
+        self.assertTrue((a2di[1] == ak.array([0,0], dtype=ak.int64)).all())
+        a2df = ak2D.array2D(0.5, 2, 2, dtype=ak.float64)
+        self.assertTrue((a2df[0] == ak.array([0.5,0.5], dtype=ak.float64)).all())
+        self.assertTrue((a2df[1] == ak.array([0.5,0.5], dtype=ak.float64)).all())
+
     def test_reshape(self):
         a = ak.array([1,2,3,4])
         a2d = ak2D.reshape(a, (2, 2))

--- a/base_test.py
+++ b/base_test.py
@@ -36,7 +36,7 @@ class ArkoudaTest(unittest.TestCase):
         if TestRunningMode.CLASS_SERVER == ArkoudaTest.test_running_mode:
             try:
                 nl = get_arkouda_numlocales()
-                ArkoudaTest.server, _, _ = start_arkouda_server(numlocales=nl, port=ArkoudaTest.port)
+                ArkoudaTest.server, _, _ = start_arkouda_server(numlocales=nl, host=ArkoudaTest.server, port=ArkoudaTest.port)
                 print('Started arkouda_server in TEST_CLASS mode with host: {} port: {} locales: {}'. \
                       format(ArkoudaTest.server, ArkoudaTest.port, nl))
             except Exception as e:


### PR DESCRIPTION
This updates Ben McD's BlockArrays2D module to use JSON message arguments, in line with Arkouda main repo HEAD. It also adds a test for the `array2D` creation function, and updates the `base_test` class to explicitly pass the server name to `start_arkouda_server` (which otherwise will try to read the server name from a config file).