### PR TITLE
update arkouda full stack dockerfile add to docs

### DIFF
--- a/arkouda-docker/README.md
+++ b/arkouda-docker/README.md
@@ -144,3 +144,7 @@ docker build --build-arg CHAPEL_UDP_IMAGE=$CHAPEL_UDP_IMAGE \
              --build-arg ARKOUDA_INTEGRATION_DOWNLOAD_URL=$ARKOUDA_INTEGRATION_DOWNLOAD_URL \
              -f arkouda-udp-server -t $ARKOUDA_IMAGE_REPO/arkouda-udp-server:$ARKOUDA_DISTRO_NAME .
 ```
+
+## Launching arkouda-udp-server
+
+The arkouda-udp-server docker image is designed to be launched on Kubernetes via Helm. The Arkouda-on-Kubernetes deployment will be added to arkoud-contrib in the near future.

--- a/arkouda-docker/README.md
+++ b/arkouda-docker/README.md
@@ -10,9 +10,9 @@ and ipython interface to Arkouda.
 ```
 # set env variables
 export CHAPEL_SMP_IMAGE=chapel/chapel-gasnet-smp:1.29.0
-export ARKOUDA_BRANCH_NAME=2023.01.11
-export ARKOUDA_DISTRO_NAME=v2023.01.11
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.01.11.zip
+export ARKOUDA_BRANCH_NAME=2023.02.08
+export ARKOUDA_DISTRO_NAME=v2023.02.08
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.02.08.zip
 export ARKOUDA_IMAGE_REPO=bearsrus
 
 docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
@@ -31,7 +31,7 @@ By default arkouda-full-stack launches a jupyter notebook that is accessible via
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2023.01.11
+export ARKOUDA_VERSION=v2023.02.08
 
 docker run -it --rm -p 8888:8888 $ARKOUDA_IMAGE_REPO/arkouda-full-stack:$ARKOUDA_VERSION
 ```
@@ -43,7 +43,7 @@ To mount a directory containing files to be analyzed, execute the following comm
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2023.01.11
+export ARKOUDA_VERSION=v2023.02.08
 export HOST_DIR=/opt/datafiles
 export CONTAINER_DIR=/app/data
 
@@ -59,7 +59,7 @@ command is as follows:
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2023.01.11
+export ARKOUDA_VERSION=v2023.02.08
 
 docker run -it --rm --entrypoint=/opt/start-arkouda-full-stack.sh \
                     $ARKOUDA_IMAGE_REPO/arkouda-full-stack:$ARKOUDA_VERSION
@@ -76,9 +76,9 @@ The arkouda-smp-server extends chapel-gasnet-smp to deliver a GASNET smp configu
 
 ```
 export CHAPEL_SMP_IMAGE=chapel/chapel-gasnet-smp:1.29.0
-export ARKOUDA_DISTRO_NAME=v2023.01.11
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.01.11.zip
-export ARKOUDA_BRANCH_NAME=2023.01.11
+export ARKOUDA_DISTRO_NAME=v2023.02.08
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.02.08.zip
+export ARKOUDA_BRANCH_NAME=2023.02.08
 export ARKOUDA_IMAGE_REPO=bearsrus
 
 docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
@@ -93,7 +93,7 @@ docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2022.11.17
+export ARKOUDA_VERSION=v2023.02.08
 
 docker run -it --rm -p 5555:5555 $ARKOUDA_IMAGE_REPO/arkouda-smp-server:$ARKOUDA_VERSION
 ```
@@ -129,9 +129,9 @@ The arkouda-udp-server image delivers a GASNET udp configuration that enables de
 
 ```
 export CHAPEL_UDP_IMAGE=bearsrus/chapel-gasnet-udp:1.29.0
-export ARKOUDA_DISTRO_NAME=v2023.01.11
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.01.11.zip
-export ARKOUDA_BRANCH_NAME=2023.01.11
+export ARKOUDA_DISTRO_NAME=v2023.02.08
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.02.08.zip
+export ARKOUDA_BRANCH_NAME=2023.02.08
 export ARKOUDA_INTEGRATION_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda-contrib/archive/refs/heads/main.zip
 export ARKOUDA_INTEGRATION_DISTRO_NAME=main
 export ARKOUDA_IMAGE_REPO=bearsrus

--- a/arkouda-docker/README.md
+++ b/arkouda-docker/README.md
@@ -2,7 +2,8 @@
 
 ## Background
 
-The arkouda-full-stack image starts a one-locale arkouda\_server and provides an ipython interface to Arkouda.
+The arkouda-full-stack image starts a one-locale arkouda\_server and provides both jupyter notebook
+and ipython interface to Arkouda.
 
 ## Building arkouda-full-stack
 
@@ -23,6 +24,8 @@ docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
 
 ## Running arkouda-full-stack
 
+By default arkouda-full-stack launches a jupyter notebook that is accessible via http://$HOSTNAME:8888
+
 ### Basic Configuration
 
 ```
@@ -38,20 +41,36 @@ docker run -it --rm -p 8888:8888 $ARKOUDA_IMAGE_REPO/arkouda-full-stack:$ARKOUDA
 To mount a directory containing files to be analyzed, execute the following command:
 
 ```
+# set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
 export ARKOUDA_VERSION=v2023.01.11
-export HOST_DIRECTORY=/opt/datafiles
-export CONTAINER_DIRECTORY=/tmp/files
+export HOST_DIR=/opt/datafiles
+export CONTAINER_DIR=/app/data
 
-docker run -it --rm -p 8888:8888 --mount type=bind,source=$HOST_DIRECTORY,target=$CONTAINER_DIRECTORY \
-       $ARKOUDA_IMAGE_REPO/arkouda-full-stack:$ARKOUDA_VERSION
+docker run -it --rm -p 8888:8888 --mount type=bind,source=$HOST_DIR,target=$CONTAINER_DIR \
+                    $ARKOUDA_IMAGE_REPO/arkouda-full-stack:$ARKOUDA_VERSION
+```
+
+#### Launch with ipython Interface
+
+If preferred, arkouda-full-stack also enables an ipython interface to Arkouda. The corresponding docker launch
+command is as follows:
+
+```
+# set env variables
+export ARKOUDA_IMAGE_REPO=bearsrus
+export ARKOUDA_VERSION=v2023.01.11
+
+docker run -it --rm --entrypoint=/opt/start-arkouda-full-stack.sh \
+                    $ARKOUDA_IMAGE_REPO/arkouda-full-stack:$ARKOUDA_VERSION
 ```
 
 # arkouda-smp-server
 
 ## Background
 
-The arkouda-smp-server extends chapel-gasnet-smp to deliver a GASNET smp configuration that enables 1..n Chapel locales within a single docker container.
+The arkouda-smp-server extends chapel-gasnet-smp to deliver a GASNET smp configuration that enables 
+1..n Chapel locales within a single docker container.
 
 ## Building arkouda-smp-server
 
@@ -83,9 +102,12 @@ docker run -it --rm -p 5555:5555 $ARKOUDA_IMAGE_REPO/arkouda-smp-server:$ARKOUDA
 
 ## Background
 
-While arkouda-smp-server extends [chapel-gasnet-smp](https://hub.docker.com/r/chapel/chapel-gasnet-smp), there is no corresponding chapel-gasnet-udp image. Accordingly, the chapel-gasnet-udp image provide a base for arkouda-udp-server
+While arkouda-smp-server extends [chapel-gasnet-smp](https://hub.docker.com/r/chapel/chapel-gasnet-smp), there is 
+no corresponding chapel-gasnet-udp image. Accordingly, the chapel-gasnet-udp image provide a base for arkouda-udp-server
 
-While arkouda-smp-server extends [chapel-gasnet-smp](https://hub.docker.com/r/chapel/chapel-gasnet-smp), there is no corresponding chapel-gasnet-udp image. chapel-gasnet-udp is a Chapel base image that enables gasnet/udp comms across 1..n locales. Accordingly, the chapel-gasnet-udp image provides a base image for the arkouda-udp-server.
+While arkouda-smp-server extends [chapel-gasnet-smp](https://hub.docker.com/r/chapel/chapel-gasnet-smp), there is 
+no corresponding chapel-gasnet-udp image. chapel-gasnet-udp is a Chapel base image that enables gasnet/udp comms 
+across 1..n locales. Accordingly, the chapel-gasnet-udp image provides a base image for the arkouda-udp-server.
 
 ## Building chapel-gasnet-udp
 

--- a/arkouda-docker/arkouda-full-stack
+++ b/arkouda-docker/arkouda-full-stack
@@ -39,7 +39,7 @@ RUN pip3 install jupyterlab
 ADD scripts/start-smp-arkouda-full-stack.sh /opt/start-arkouda-full-stack.sh
 ADD scripts/start-smp-arkouda-full-stack-notebook.sh /opt/start-arkouda-full-stack-notebook.sh
 RUN chmod +x /opt/start-arkouda-full-stack.sh /opt/start-arkouda-full-stack-notebook.sh
-ENTRYPOINT sh /opt/start-smp-arkouda-full-stack-notebook.sh
+ENTRYPOINT sh /opt/start-arkouda-full-stack-notebook.sh
 
-WORKDIR /opt
+WORKDIR /opt/arkouda
 EXPOSE 8888

--- a/arkouda-docker/arkouda-full-stack
+++ b/arkouda-docker/arkouda-full-stack
@@ -37,6 +37,9 @@ RUN pip3 install jupyterlab
 
 # Add startup script and set as entrypoint
 ADD scripts/start-smp-arkouda-full-stack.sh /opt/start-arkouda-full-stack.sh
-ENTRYPOINT sh /opt/start-arkouda-full-stack.sh
+ADD scripts/start-smp-arkouda-full-stack-notebook.sh /opt/start-arkouda-full-stack-notebook.sh
+RUN chmod +x /opt/start-arkouda-full-stack.sh /opt/start-arkouda-full-stack-notebook.sh
+ENTRYPOINT sh /opt/start-smp-arkouda-full-stack-notebook.sh
 
-EXPOSE 5555
+WORKDIR /opt
+EXPOSE 8888


### PR DESCRIPTION
Closes #74 

This  PR does the following:

1. Adds the start-arkouda-full-stack-notebook.sh script to the arkouda-full-stack Dockerfile
2. Enables both the ipython and notebook startup scripts to serve as entrypoints
3. Defaults to the start-arkouda-full-stack-notebook.sh script (launches jupyter notebook)
4. Updated README accordingly
5. Added mention of arkouda-udp-server use case (Arkouda-on-Kubernetes deployment)