### PR TITLE
78 arkouda docker python image build script

### DIFF
--- a/arkouda-docker/README.md
+++ b/arkouda-docker/README.md
@@ -148,3 +148,64 @@ docker build --build-arg CHAPEL_UDP_IMAGE=$CHAPEL_UDP_IMAGE \
 ## Launching arkouda-udp-server
 
 The arkouda-udp-server docker image is designed to be launched on Kubernetes via Helm. The Arkouda-on-Kubernetes deployment will be added to arkouda-contrib in the near future.
+
+# Building Images with Python script
+
+## Background
+
+The [build_docker_image.py](./build_docker_image.py) python script is a convenient means of building all for arkouda-docker images. 
+
+## Python Docker build script
+
+The --help command displays the docker build parameters:
+
+```
+python build_docker_image.py --help
+usage: build_docker_image.py [-h] [--image_type IMAGE_TYPE] [--arkouda_tag ARKOUDA_TAG] [--arkouda_branch ARKOUDA_BRANCH] [--dockerhub_repo DOCKERHUB_REPO]
+                             [--arkouda_repo ARKOUDA_REPO] [--chapel_version CHAPEL_VERSION]
+
+Build bearsrus docker images
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --image_type IMAGE_TYPE
+                        possible image types are ARKOUDA_FULL_STACK, ARKOUDA_SMP_SERVER, ARKOUDA_UDP_SERVER and CHAPEL_UDP
+  --arkouda_tag ARKOUDA_TAG
+                        if the desired arkouda version is a tag
+  --arkouda_branch ARKOUDA_BRANCH
+                        if the desired arkouda version is a branch
+  --dockerhub_repo DOCKERHUB_REPO
+                        the dockerhub repo the image is to be published, defaults to bearsrus
+  --arkouda_repo ARKOUDA_REPO
+                        the arkouda repo containing the arkouda source code, defaults to Bears-R-Us
+  --chapel_version CHAPEL_VERSION
+                        Version of Chapel used to build image
+``` 
+
+## Example Build Commands
+
+### arkouda-full-stack
+
+```
+python build_docker_image.py --arkouda_tag=v2023.02.08 --chapel_version=1.29.0 --image_type=ARKOUDA_FULL_STACK
+```
+
+### arkouda-smp-server
+
+```
+python build_docker_image.py --arkouda_tag=v2023.02.08 --chapel_version=1.29.0 --image_type=ARKOUDA_SMP_SERVER
+```
+
+### chapel-gasnet-udp
+
+```
+python build_docker_image.py --chapel_version=1.29.0 --image_type=CHAPEL_UDP
+```
+
+### arkouda-udp-server
+
+```
+python build_docker_image.py --arkouda_tag=v2023.02.08 --chapel_version=1.29.0 --image_type=ARKOUDA_UDP_SERVER
+```
+
+

--- a/arkouda-docker/README.md
+++ b/arkouda-docker/README.md
@@ -153,7 +153,7 @@ The arkouda-udp-server docker image is designed to be launched on Kubernetes via
 
 ## Background
 
-The [build_docker_image.py](./build_docker_image.py) python script is a convenient means of building all for arkouda-docker images. 
+The [build_docker_image.py](./build_docker_image.py) python script is a convenient means of building the arkouda-docker images. 
 
 ## Python Docker build script
 

--- a/arkouda-docker/README.md
+++ b/arkouda-docker/README.md
@@ -187,25 +187,25 @@ optional arguments:
 ### arkouda-full-stack
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.02.08 --chapel_version=1.29.0 --image_type=ARKOUDA_FULL_STACK
+python build_docker_image.py --arkouda_tag=v2023.02.08 --chapel_version=1.29.0 --image_type=arkouda-full-stack
 ```
 
 ### arkouda-smp-server
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.02.08 --chapel_version=1.29.0 --image_type=ARKOUDA_SMP_SERVER
+python build_docker_image.py --arkouda_tag=v2023.02.08 --chapel_version=1.29.0 --image_type=arkouda-smp-server
 ```
 
 ### chapel-gasnet-udp
 
 ```
-python build_docker_image.py --chapel_version=1.29.0 --image_type=CHAPEL_UDP
+python build_docker_image.py --chapel_version=1.29.0 --image_type=chapel-gasnet-udp
 ```
 
 ### arkouda-udp-server
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.02.08 --chapel_version=1.29.0 --image_type=ARKOUDA_UDP_SERVER
+python build_docker_image.py --arkouda_tag=v2023.02.08 --chapel_version=1.29.0 --image_type=arkouda-udp-server
 ```
 
 

--- a/arkouda-docker/build_docker_image.py
+++ b/arkouda-docker/build_docker_image.py
@@ -52,30 +52,55 @@ def buildImage(dockerRepo: str, chapelVersion: str, file: str, distro: str, tag:
     def buildArkoudaFullStack(dockerRepo: str, chapelVersion: str, file: str, dockerTag: str, distro: str, tag: Optional[str]) -> None:
         result = subprocess.run(args=['docker','build',
                                                '--build-arg', f'CHAPEL_SMP_IMAGE={generateChplSmpVersion(chapelVersion)}',
-                                               '--build-arg', f'ARKOUDA_DISTRO_NAME={distro}',
+                                               '--build-arg', f'ARKOUDA_DISTRO_NAME={getDistroName(distro=distro, tag=tag)}',
                                                '--build-arg', f'ARKOUDA_DOWNLOAD_URL={generateArkoudaDownloadUrl(tag=tag,branch=distro)}',
                                                '--build-arg', f'ARKOUDA_BRANCH_NAME={distro}',
                                                '-f',file,
                                                '-t', dockerTag, '.'], stdout=subprocess.DEVNULL)
         print(result)
 
-    def buildArkoudaSmpServer(dockerRepo: str, chapelVersion: str, file: str, distro: str, tag: Optional[str]) -> None:
+    def buildArkoudaSmpServer(dockerRepo: str, chapelVersion: str, file: str, dockerTag: str, distro: str, tag: Optional[str]) -> None:
         result = subprocess.run(args=['docker','build',
                                                '--build-arg', f'CHAPEL_SMP_IMAGE={generateChplSmpVersion(chapelVersion)}',
-                                               '--build-arg', f'ARKOUDA_DISTRO_NAME={distro}',
+                                               '--build-arg', f'ARKOUDA_DISTRO_NAME={getDistroName(distro=distro, tag=tag)}',
                                                '--build-arg', f'ARKOUDA_DOWNLOAD_URL={generateArkoudaDownloadUrl(tag=tag,branch=distro)}',
                                                '--build-arg', f'ARKOUDA_BRANCH_NAME={distro}',
                                                '-f',file,
-                                               '-t', tag, '.'], stdout=subprocess.DEVNULL)
+                                               '-t', dockerTag, '.'], stdout=subprocess.DEVNULL)
+        print(result)
+
+    def buildArkoudaUdpServer(dockerRepo: str, chapelVersion: str, file: str, dockerTag: str, distro: str, tag: Optional[str]) -> None:
+        result = subprocess.run(args=['docker','build',
+                                               '--build-arg', f'CHAPEL_UDP_IMAGE={generateChplUdpVersion(chapelVersion)}',
+                                               '--build-arg', f'ARKOUDA_DISTRO_NAME={getDistroName(distro=distro, tag=tag)}',
+                                               '--build-arg', f'ARKOUDA_DOWNLOAD_URL={generateArkoudaDownloadUrl(tag=tag,branch=distro)}',
+                                               '--build-arg', f'ARKOUDA_BRANCH_NAME={distro}',
+                                               '--build-arg', 'ARKOUDA_INTEGRATION_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda-contrib/archive/refs/heads/main.zip',
+                                               '--build-arg', 'ARKOUDA_INTEGRATION_DISTRO_NAME=main',
+                                               '-f',file,
+                                               '-t', dockerTag, '.'], stdout=subprocess.DEVNULL)
         print(result)
 
     dockerTag = generateBuildTag(dockerRepo=dockerRepo, file=file, tag=tag,distro=distro)
-    print(dockerTag)
+
     if file == 'arkouda-full-stack':   
-        buildArkoudaFullStack(dockerRepo=dockerRepo,chapelVersion=chapelVersion,file=file,dockerTag=dockerTag,distro=distro,tag=tag) 
+        buildArkoudaFullStack(dockerRepo=dockerRepo,chapelVersion=chapelVersion,file=file,dockerTag=dockerTag,distro=distro,tag=tag)
+    elif file == 'arkouda-smp-server':
+        buildArkoudaSmpServer(dockerRepo=dockerRepo,chapelVersion=chapelVersion,file=file,dockerTag=dockerTag,distro=distro,tag=tag)
+    elif file == 'arkouda-udp-server':
+        buildArkoudaUdpServer(dockerRepo=dockerRepo,chapelVersion=chapelVersion,file=file,dockerTag=dockerTag,distro=distro,tag=tag)
+
+def getDistroName(distro: str, tag: Optional[str]) -> str:
+    if tag:
+        return tag
+    else:
+        return distro
 
 def generateChplSmpVersion(chapelVersion: str) -> str:
     return f'chapel/chapel-gasnet-smp:{chapelVersion}'
+
+def generateChplUdpVersion(chapelVersion: str) -> str:
+    return f'bearsrus/chapel-gasnet-udp:{chapelVersion}'
 
 def generateArkoudaDownloadUrl(tag: Optional[str], branch: Optional[str]) -> str:
     if tag:

--- a/arkouda-docker/build_docker_image.py
+++ b/arkouda-docker/build_docker_image.py
@@ -9,7 +9,7 @@ class ImageType(Enum):
     ARKOUDA_FULL_STACK = 'arkouda-full-stack'
     ARKOUDA_SMP_SERVER = 'arkouda-smp-server'
     ARKOUDA_UDP_SERVER = 'arkouda-udp-server'
-    CHAPEL_UDP = 'chapel-gasnet-udp'
+    CHAPEL_GASNET_UDP = 'chapel-gasnet-udp'
 
 def getImageFile(imageType: ImageType) -> str:
     '''
@@ -86,11 +86,11 @@ def buildImage(dockerRepo: str, chapelVersion: str, file: str, distro: str, tag:
 
     dockerTag = generateBuildTag(dockerRepo=dockerRepo, file=file, tag=tag,distro=distro)
 
-    if file == 'arkouda-full-stack':   
+    if file == ImageType.ARKOUDA_FULL_STACK.value:
         buildArkoudaFullStack(dockerRepo=dockerRepo,chapelVersion=chapelVersion,file=file,dockerTag=dockerTag,distro=distro,tag=tag)
-    elif file == 'arkouda-smp-server':
+    elif file == ImageType.ARKOUDA_SMP_SERVER.value:
         buildArkoudaSmpServer(dockerRepo=dockerRepo,chapelVersion=chapelVersion,file=file,dockerTag=dockerTag,distro=distro,tag=tag)
-    elif file == 'arkouda-udp-server':
+    elif file == ImageType.ARKOUDA_UDP_SERVER.value:
         buildArkoudaUdpServer(dockerRepo=dockerRepo,chapelVersion=chapelVersion,file=file,dockerTag=dockerTag,distro=distro,tag=tag)
     else:
         buildChapelUdp(dockerRepo=dockerRepo,chapelVersion=chapelVersion,file=file,dockerTag=dockerTag)

--- a/arkouda-docker/build_docker_image.py
+++ b/arkouda-docker/build_docker_image.py
@@ -96,10 +96,16 @@ def buildImage(dockerRepo: str, chapelVersion: str, file: str, distro: str, tag:
         buildChapelUdp(dockerRepo=dockerRepo,chapelVersion=chapelVersion,file=file,dockerTag=dockerTag)
 
 def getDistroName(distro: str, tag: Optional[str]) -> str:
-    if tag:
-        return tag
-    else:
-        return distro
+    '''
+    Returns the distro name used to specify the name of the Arkouda distribution that is
+    either a tag or a branch.
+
+    :param str distro: name of Arkouda distro (branch)
+    :param Optional[str] tag: name of Arkouda tag
+    :return: tag or branch name
+    :rtype:str
+    '''
+    return tag if tag else distro
 
 def generateChplSmpVersion(chapelVersion: str) -> str:
     return f'chapel/chapel-gasnet-smp:{chapelVersion}'

--- a/arkouda-docker/build_docker_image.py
+++ b/arkouda-docker/build_docker_image.py
@@ -6,10 +6,10 @@ class ImageType(Enum):
     '''
     The ImageType enum provides controlled vocabulary for the docker image type
     '''
-    ARKOUDA_FULL_STACK = 'ARKOUDA_FULL_STACK'
-    ARKOUDA_SMP_SERVER = 'ARKOUDA_SMP_SERVER'
-    ARKOUDA_UDP_SERVER = 'ARKOUDA_UDP_SERVER'
-    CHAPEL_UDP = 'CHAPEL_UDP'
+    ARKOUDA_FULL_STACK = 'arkouda-full-stack'
+    ARKOUDA_SMP_SERVER = 'arkouda-smp-server'
+    ARKOUDA_UDP_SERVER = 'arkouda-udp-server'
+    CHAPEL_UDP = 'chapel-gasnet-udp'
 
 def getImageFile(imageType: ImageType) -> str:
     '''
@@ -19,14 +19,7 @@ def getImageFile(imageType: ImageType) -> str:
     :return: Dockerfile corresponding to the image type
     :rtype: str
     '''
-    if ImageType.ARKOUDA_FULL_STACK == imageType:
-        return 'arkouda-full-stack'
-    elif ImageType.ARKOUDA_SMP_SERVER == imageType:
-        return 'arkouda-smp-server'
-    elif ImageType.ARKOUDA_UDP_SERVER == imageType:
-        return 'arkouda-udp-server'
-    elif ImageType.CHAPEL_UDP == imageType:
-        return 'chapel-gasnet-udp'
+    return imageType.value
 
 def getDistro(tag: str) -> str:
     '''
@@ -163,7 +156,7 @@ if __name__=="__main__":
     parser = argparse.ArgumentParser(description='Build bearsrus docker images')
 
     parser.add_argument('--image_type', type=ImageType,
-                        help='possible image types are ARKOUDA_FULL_STACK, ARKOUDA_SMP_SERVER, ARKOUDA_UDP_SERVER and CHAPEL_UDP')
+                        help='possible image types are arkouda_full_stack, arkouda-smp-server, arkouda-udp-server and chapel_udp')
     parser.add_argument('--arkouda_tag', type=str,
                         help='if the desired arkouda version is a tag')
     parser.add_argument('--arkouda_branch', type=str, 

--- a/arkouda-docker/build_docker_image.py
+++ b/arkouda-docker/build_docker_image.py
@@ -143,10 +143,7 @@ def generateBuildTag(dockerRepo: str, file: str, tag: Optional[str], distro: Opt
     :return: docker build tag 
     :rtype: str
     '''
-    if tag:
-        return f'{dockerRepo}/{file}:{tag}'
-    else:
-        return f'{dockerRepo}/{file}:{distro}'   
+    return f'{dockerRepo}/{file}:{tag}' if tag else f'{dockerRepo}/{file}:{distro}'
 
 def buildArkoudaImage(dockerFile: str) -> bool:
     '''

--- a/arkouda-docker/build_docker_image.py
+++ b/arkouda-docker/build_docker_image.py
@@ -15,7 +15,7 @@ def getImageFile(imageType: ImageType) -> str:
     '''
     Returns the Dockerfile per the image type
 
-    
+    :param ImageType imageType: Docker image type enum    
     :return: Dockerfile corresponding to the image type
     :rtype: str
     '''
@@ -49,9 +49,28 @@ def buildImage(repo: str, chapelVersion: str, file: str, distro: str, tag: Optio
     :param Optional[str] tag: Arkouda tag name, if applicable
     :return: None
     '''
+    def buildArkoudaFullStack(repo: str, chapelVersion: str, file: str, distro: str, tag: Optional[str]) -> None:
+        p = subprocess.Popen(shell=True, args=['docker','build',
+                                               '--build-arg', f'CHPL_SMP_IMAGE={generateChplSmpVersion(chapelVersion)}',
+                                               '--build-arg', f'ARKOUDA_DISTRO_NAME={distro}',
+                                               '--build-arg', f'ARKOUDA_DOWNLOAD_URL={generateArkoudaDownloadUrl(tag=tag,distro=distro)}',
+                                               '--build-arg', f'ARKOUDA_BRANCH_NAME={distro}',
+                                               '-f',file,
+                                               '-t', f'{repo}/arkouda-full-stack:{tag}'])
+
     buildTag = generateBuildTag(repo=repo, file=file, tag=tag,distro=distro)
-    print(buildTag)
-    #p = subprocess.Popen(shell=True, args=['docker','build','-f',image,chapelVersion])
+    print(buildTag)    
+
+def generateChapelSmpVersion(chapelVersion: str) -> str:
+    return f'chapel/chapel-gasnet-smp:{chapelVersion}'
+
+def generateArkoudaDownloadUrl(tag: Optional[str], branch: Optional[str]) -> str:
+    if tag:
+        return f'https://github.com/Bears-R-Us/arkouda/archive/refs/tags/{tag}.zip'
+    elif branch:
+        return f'https://github.com/Bears-R-Us/arkouda/archive/refs/heads/{branch}.zip'
+    else:
+        raise ValueError('either the tag or branch must be not None')
 
 def generateBuildTag(repo: str, file: str, tag: Optional[str], distro: Optional[str]) -> str:
     '''

--- a/arkouda-docker/build_docker_image.py
+++ b/arkouda-docker/build_docker_image.py
@@ -1,0 +1,102 @@
+import argparse, enum, subprocess, sys
+from typing import Optional
+from enum import Enum
+
+class ImageType(Enum):
+    '''
+    The ImageType enum provides controlled vocabulary for the docker image type
+    '''
+    ARKOUDA_FULL_STACK = 'ARKOUDA_FULL_STACK'
+    ARKOUDA_SMP_SERVER = 'ARKOUDA_SMP_SERVER'
+    ARKOUDA_UDP_SERVER = 'ARKOUDA_UDP_SERVER'
+    CHAPEL_UDP = 'CHAPEL_UDP'
+
+def getImageFile(imageType: ImageType) -> str:
+    '''
+    Returns the Dockerfile per the image type
+
+    
+    :return: Dockerfile corresponding to the image type
+    :rtype: str
+    '''
+    if ImageType.ARKOUDA_FULL_STACK == imageType:
+        return 'arkouda-full-stack'
+    elif ImageType.ARKOUDA_SMP_SERVER == imageType:
+        return 'arkouda-smp-server'
+    elif ImageType.ARKOUDA_UDP_SERVER == imageType:
+        return 'arkouda-udp-server'
+    elif ImageType.CHAPEL_UDP == imageType:
+        return 'chapel-gasnet-udp'
+
+def getDistro(tag: str) -> str:
+    '''
+    Returns the distro name corresponding to the Arkouda tag
+
+    :param str tag: Arkouda tag
+    :return: distro name 
+    :rtype: str
+    '''
+    return tag.lstrip('v')
+
+def buildImage(repo: str, chapelVersion: str, file: str, distro: str, tag: Optional[str]) -> None:
+    '''
+    Generates a build tag and then builds the desired docker image
+
+    :param str repo: dockerhub repo the image will be published to
+    :param str chapelVersion: version of Chapel used to build Arkouda server
+    :param str file: Dockerfile name
+    :param str distro: Arkouda distro (branch name)
+    :param Optional[str] tag: Arkouda tag name, if applicable
+    :return: None
+    '''
+    buildTag = generateBuildTag(repo=repo, file=file, tag=tag,distro=distro)
+    print(buildTag)
+    #p = subprocess.Popen(shell=True, args=['docker','build','-f',image,chapelVersion])
+
+def generateBuildTag(repo: str, file: str, tag: Optional[str], distro: Optional[str]) -> str:
+    '''
+    Generates a docker build tag corresponding to the repo, file, tag, an distro
+
+    :param str repo: dockerhub repo the image will be published to
+    :param str file: Dockerfile name
+    :param Optional[str] tag: Arkouda tag name, if applicable
+    :param Optional[str] distro: Arkouda distro (branch name), if applicable
+
+    :return: docker build tag 
+    :rtype: str
+    '''
+    if tag:
+        return f'{repo}/{file}:{tag}'
+    else:
+        return f'{repo}/{file}:{distro}'   
+
+if __name__=="__main__":
+    parser = argparse.ArgumentParser(description='Build bearsrus docker images')
+
+    parser.add_argument('--image_type', type=ImageType,
+                        help='possible image types are ARKOUDA_FULL_STACK, ARKOUDA_SMP_SERVER, ARKOUDA_UDP_SERVER and CHAPEL_UDP')
+    parser.add_argument('--arkouda_tag', type=str,
+                        help='if the desired arkouda version is a tag')
+    parser.add_argument('--arkouda_branch', type=str, 
+                        help='if the desired arkouda version is a branch')
+    parser.add_argument('--dockerhub_repo', type=str, default='Bears-R-Us',
+                        help='the dockerhub repo the image is to be published, defaults to Bears-R-Us')
+    parser.add_argument('--chapel_version', type=str,
+                        help='Version of Chapel used to build image')
+
+    args = parser.parse_args()
+
+    file = getImageFile(args.image_type)
+    tag = args.arkouda_tag
+    repo = args.dockerhub_repo
+    chapelVersion = args.chapel_version
+
+    if tag:
+        distro = getDistro(tag)
+    else:
+        if args.arkouda_branch:
+            distro = args.arkouda_branch
+        else:
+            raise ValueError('Either --arkouda_tag or --arkouda_branch must be specified')
+    
+    buildImage(repo=repo,chapelVersion=chapelVersion,file=file,tag=tag,distro=distro)


### PR DESCRIPTION
Closes #78 

This PR adds a python docker build script that simplifies the process of building Arkouda docker images as well as the chapel-gasnet-udp image that serves as the base image for arkouda-udp-server