### PR TITLE
add chapel gasnet smp image

### DIFF
--- a/arkouda-docker/README.md
+++ b/arkouda-docker/README.md
@@ -75,7 +75,7 @@ The arkouda-smp-server extends chapel-gasnet-smp to deliver a GASNET smp configu
 ## Building arkouda-smp-server
 
 ```
-export CHAPEL_SMP_IMAGE=chapel/chapel-gasnet-smp:1.30.0
+export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.30.0
 export ARKOUDA_DISTRO_NAME=v2023.04.07
 export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.04.07.zip
 export ARKOUDA_BRANCH_NAME=2023.04.07

--- a/arkouda-docker/README.md
+++ b/arkouda-docker/README.md
@@ -9,7 +9,7 @@ and ipython interface to Arkouda.
 
 ```
 # set env variables
-export CHAPEL_SMP_IMAGE=chapel/chapel-gasnet-smp:1.30.0
+export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.30.0
 export ARKOUDA_BRANCH_NAME=2023.04.07
 export ARKOUDA_DISTRO_NAME=v2023.04.07
 export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.04.07.zip
@@ -227,6 +227,12 @@ Shown below are example build commands. To ensure the optimal, respective perfor
 
 ```
 python build_docker_image.py --arkouda_tag=v2023.04.07 --chapel_version=1.30.0 --image_type=arkouda-full-stack
+```
+
+### chapel-gasnet-smp
+
+```
+python build_docker_image.py --chapel_version=1.30.0 --image_type=chapel-gasnet-smp
 ```
 
 ### arkouda-smp-server

--- a/arkouda-docker/arkouda-full-stack
+++ b/arkouda-docker/arkouda-full-stack
@@ -1,13 +1,11 @@
-ARG CHAPEL_SMP_IMAGE
-FROM $CHAPEL_SMP_IMAGE
+ARG CHAPEL_SMP_IMAGE=${CHAPEL_SMP_IMAGE}
 
-# hack needed for Kubernetes deployment
-RUN export CHPL_GASNET_MORE_CFG_OPTIONS=--enable-force-posix-realtime
-WORKDIR $CHPL_HOME
-RUN touch third-party/gasnet/Makefile
-RUN make -j
+FROM ${CHAPEL_SMP_IMAGE}
 
-# get env variables for arkouda download and install
+WORKDIR /opt
+RUN sudo chmod 777 /opt
+
+# Download Arkouda
 ARG ARKOUDA_DOWNLOAD_URL=${ARKOUDA_DOWNLOAD_URL}
 ENV ARKOUDA_DOWNLOAD_URL=${ARKOUDA_DOWNLOAD_URL}
 ARG ARKOUDA_DISTRO_NAME=${ARKOUDA_DISTRO_NAME}
@@ -15,31 +13,44 @@ ENV ARKOUDA_DISTRO_NAME=${ARKOUDA_DISTRO_NAME}
 ARG ARKOUDA_BRANCH_NAME=${ARKOUDA_BRANCH_NAME}
 ENV ARKOUDA_BRANCH_NAME=${ARKOUDA_BRANCH_NAME}
 
-RUN apt-get update && apt install unzip libcurl4-openssl-dev -y
+# Install dependencies
+RUN sudo apt-get update && sudo apt upgrade -y && \
+    sudo apt-get install unzip libcurl4-openssl-dev -y
 
-WORKDIR /opt
-
-# Download desired Arkouda distro, move to common /opt/arkouda dir
-RUN chmod 777 /opt && \
-    wget $ARKOUDA_DOWNLOAD_URL && \
+# Download desired Arkouda distro, move to commont /opt/arkouda dir
+RUN wget $ARKOUDA_DOWNLOAD_URL && \
     unzip $ARKOUDA_DISTRO_NAME.zip && \
     mv /opt/arkouda-$ARKOUDA_BRANCH_NAME /opt/arkouda
 
 WORKDIR /opt/arkouda
 
+# Install Arkouda server
 RUN make install-deps && make
 
-# Install python client
-RUN pip3 install -e .[dev]
+# Install Arkouda python client, ipython, and jupyter
+RUN sudo python3 setup.py bdist_wheel --universal && \
+    sudo pip3 install dist/*.whl && \
+    sudo pip3 install jupyter ipython
 
-# Install jupyterlab
-RUN pip3 install jupyterlab
+# Remove unneeded files
+RUN sudo rm -rf /opt/$ARKOUDA_DISTRO_NAME.zip && \
+    sudo rm -rf /opt/chapel && \
+    cd /opt/arkouda && \
+    sudo rm -rf benchmarks converter examples *.md pictures pydoc resources runs src test tests toys
 
-# Add startup script and set as entrypoint
-ADD scripts/start-smp-arkouda-full-stack.sh /opt/start-arkouda-full-stack.sh
-ADD scripts/start-smp-arkouda-full-stack-notebook.sh /opt/start-arkouda-full-stack-notebook.sh
-RUN chmod +x /opt/start-arkouda-full-stack.sh /opt/start-arkouda-full-stack-notebook.sh
-ENTRYPOINT sh /opt/start-arkouda-full-stack-notebook.sh
+# Add startup scripts
+ADD scripts/start-smp-arkouda-full-stack.sh /opt/arkouda/start-smp-arkouda-full-stack.sh 
+ADD scripts/start-smp-arkouda-full-stack-notebook.sh /opt/arkouda/start-smp-arkouda-full-stack-notebook.sh
 
-WORKDIR /opt/arkouda
+# Create jovyan user and make entrypoint scripts executable
+RUN sudo useradd -m jovyan && \
+    sudo chmod +x /opt/arkouda/start-smp-arkouda-full-stack.sh && \
+    sudo chmod +x /opt/arkouda/start-smp-arkouda-full-stack-notebook.sh
+
+# Switch to jovyan user
+USER jovyan
+WORKDIR /home/jovyan
+
+ENTRYPOINT /opt/arkouda/start-smp-arkouda-full-stack-notebook.sh 
+
 EXPOSE 8888

--- a/arkouda-docker/arkouda-smp-server
+++ b/arkouda-docker/arkouda-smp-server
@@ -1,13 +1,8 @@
-ARG CHAPEL_SMP_IMAGE
-FROM $CHAPEL_SMP_IMAGE
+ARG CHAPEL_SMP_IMAGE=${CHAPEL_SMP_IMAGE}
 
-# hack needed for Kubernetes deploymet
-RUN export CHPL_GASNET_MORE_CFG_OPTIONS=--enable-force-posix-realtime
-WORKDIR $CHPL_HOME
-RUN touch third-party/gasnet/Makefile
-RUN make -j
+FROM ${CHAPEL_SMP_IMAGE}
 
-# get env variables for arkouda download and install
+# Set arkouda env variables
 ARG ARKOUDA_DOWNLOAD_URL=${ARKOUDA_DOWNLOAD_URL}
 ENV ARKOUDA_DOWNLOAD_URL=${ARKOUDA_DOWNLOAD_URL}
 ARG ARKOUDA_DISTRO_NAME=${ARKOUDA_DISTRO_NAME}
@@ -15,23 +10,34 @@ ENV ARKOUDA_DISTRO_NAME=${ARKOUDA_DISTRO_NAME}
 ARG ARKOUDA_BRANCH_NAME=${ARKOUDA_BRANCH_NAME}
 ENV ARKOUDA_BRANCH_NAME=${ARKOUDA_BRANCH_NAME}
 
-RUN apt-get update && apt install unzip hdf5-tools libcurl4-openssl-dev -y
-
 WORKDIR /opt
+RUN sudo chmod 777 /opt
 
-# Download desired Arkouda distro, move to common /opt/arkouda dir
-RUN chmod 777 /opt && \
-    wget $ARKOUDA_DOWNLOAD_URL && \
+# Install dependencies
+RUN sudo apt-get update && sudo apt upgrade -y && \
+    sudo apt-get install unzip libcurl4-openssl-dev -y
+
+# Download desired Arkouda distro, move to commont /opt/arkouda dir
+RUN wget $ARKOUDA_DOWNLOAD_URL && \
     unzip $ARKOUDA_DISTRO_NAME.zip && \
-    mv /opt/arkouda-$ARKOUDA_BRANCH_NAME /opt/arkouda
+    mv /opt/arkouda-$ARKOUDA_BRANCH_NAME /opt/arkouda 
 
 WORKDIR /opt/arkouda
 
-# Install deps and build Arkouda 
-RUN make install-deps && make
+# Build and install deps
+RUN make install-deps
 
-# Add startup script and set as entrypoint
-ADD scripts/start-smp-arkouda-server.sh /opt/start-arkouda-server.sh
-ENTRYPOINT sh /opt/start-arkouda-server.sh
+# Build Arkouda
+RUN make
+
+# Remove unneeded files
+RUN sudo rm -rf /opt/$ARKOUDA_DISTRO_NAME.zip && \
+    sudo rm -rf /opt/chapel && \
+    cd /opt/arkouda && \
+    sudo rm -rf benchmarks converter examples *.md pictures pydoc resources runs src test tests toys
+
+# Add startup script and set entrypoint
+ADD scripts/start-smp-arkouda-server.sh /opt/arkouda/start-smp-arkouda-server.sh
+ENTRYPOINT sh /opt/arkouda/start-smp-arkouda-server.sh
 
 EXPOSE 5555

--- a/arkouda-docker/chapel-gasnet-smp
+++ b/arkouda-docker/chapel-gasnet-smp
@@ -1,5 +1,7 @@
-ARG CHPL_BASE_IMAGE
-FROM $CHPL_BASE_IMAGE
+FROM ubuntu:22.04
+
+ARG CHPL_VERSION=${CHPL_VERSION}
+ENV CHPL_VERSION=${CHPL_VERSION}
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -49,15 +51,15 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
            
 EXPOSE 22
 
-ARG CHPL_VERSION=${CHPL_VERSION}
-ENV CHPL_VERSION=${CHPL_VERSION}
 ENV CHPL_HOME=/opt/chapel/$CHPL_VERSION
 
+ENV CHPL_TARGET_PLATFORM=linux64
 ENV CHPL_COMM_SUBSTRATE=smp
 ENV CHPL_COMM=gasnet
+ENV CHPL_LAUNCHER=smp
 ENV CHPL_LLVM=system
-ENV CHPL_RE2=bundled
 ENV CHPL_GMP=system
+ENV CHPL_RE2=bundled
 RUN chmod 777 /opt
 
 USER ubuntu
@@ -66,7 +68,6 @@ RUN mkdir /home/ubuntu/.ssh
 RUN mkdir -p /opt/chapel \
     && wget -q -O - https://github.com/chapel-lang/chapel/releases/download/$CHPL_VERSION/chapel-$CHPL_VERSION.tar.gz | tar -xzC /opt/chapel --transform 's/chapel-//' \
     && make -C $CHPL_HOME \
-    #&& make -C $CHPL_HOME chpldoc test-venv mason \
     && make -C $CHPL_HOME cleanall
 
 USER root

--- a/arkouda-docker/chapel-gasnet-smp
+++ b/arkouda-docker/chapel-gasnet-smp
@@ -1,0 +1,77 @@
+ARG CHPL_BASE_IMAGE
+FROM $CHPL_BASE_IMAGE
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV CHPL_GASNET_MORE_CFG_OPTIONS "--disable-pshm-posix --enable-pshm-sysv"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    ca-certificates \
+    cmake \
+    curl \
+    gcc \
+    g++ \
+    perl \
+    python2.7 \
+    python2.7-dev \
+    python-setuptools \
+    python3 \
+    python3-pip \
+    libgmp10 \
+    libgmp-dev \
+    locales \
+    bash \
+    make \
+    mawk \
+    file \
+    pkg-config \
+    git \
+    openssh-client \
+    openssh-server \
+    sshpass \
+    sudo \
+    procps \
+    dnsutils \
+    vim \
+    hdf5-tools \
+    libcurl4-openssl-dev \
+    clang \
+    lldb \
+    lld \
+    llvm-dev \
+    libclang-14-dev \
+    libclang-cpp-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m ubuntu && echo "ubuntu:ubuntu" | chpasswd && adduser ubuntu sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+           
+EXPOSE 22
+
+ARG CHPL_VERSION=${CHPL_VERSION}
+ENV CHPL_VERSION=${CHPL_VERSION}
+ENV CHPL_HOME=/opt/chapel/$CHPL_VERSION
+
+ENV CHPL_COMM_SUBSTRATE=smp
+ENV CHPL_COMM=gasnet
+ENV CHPL_LLVM=system
+ENV CHPL_RE2=bundled
+ENV CHPL_GMP=system
+RUN chmod 777 /opt
+
+USER ubuntu
+RUN mkdir /home/ubuntu/.ssh
+
+RUN mkdir -p /opt/chapel \
+    && wget -q -O - https://github.com/chapel-lang/chapel/releases/download/$CHPL_VERSION/chapel-$CHPL_VERSION.tar.gz | tar -xzC /opt/chapel --transform 's/chapel-//' \
+    && make -C $CHPL_HOME \
+    #&& make -C $CHPL_HOME chpldoc test-venv mason \
+    && make -C $CHPL_HOME cleanall
+
+USER root
+RUN chmod -R 777 /opt/chapel/$CHPL_VERSION/bin
+
+USER ubuntu
+ENV PATH=/opt/chapel/$CHPL_VERSION/bin/linux64-x86_64/:$PATH
+


### PR DESCRIPTION
Closes #88 

This PR does the following:

1. adds chapel-gasnet-smp Dockerfile
2. refactored arkouda-smp-server and arkouda-full-stack to build off bearsrus/chapel-gasnet-smp
3. Updates README.md and build_docker_image.py