### PR TITLE
add arkouda on kubernetes helm charts

### DIFF
--- a/arkouda-helm-charts/README.md
+++ b/arkouda-helm-charts/README.md
@@ -1,0 +1,17 @@
+# arkouda-helm-charts
+
+## Overviews
+
+The bears-r-us arkouda-helm-charts project provides two Helm charts that enable Arkouda to be deployed on Kubernetes as well as a Helm chart that enables Arkouda metrics to be captured in Prometheus.
+
+## arkouda-udp-locale
+
+The [arkouda-udp-locale](arkouda-udp-locale) Helm chart deploys 1..n arkouda-udp-locale docker containers that, together with the arkouda-udp-server bootstrap server, compose the Arkouda-on-Kubernetes deployment. The arkouda-udp-locale Helm chart is deployed first and, once all of the arkouda-udp-locale pods are running, the arkouda-udp-server Helm chart is deployed. The arkouda-udp-server container uses ssh to establish a gasnet/udp-managed Arkouda multi-locale instance.
+
+## arkouda-udp-server
+
+The [arkouda-udp-server](arkouda-udp-server) Helm chart deploys the containerized Arkouda server instance that bootstraps a multi-locale Arkouda cluster that communicates via gasnet/udp.
+
+## prometheus-arkouda-exporter
+
+The [prometheus-arkouda-exporter](prometheus-arkouda-exporter) Helm chart deploys a prometheus-arkouda-exporter that pulls metrics from Arkouda and serves as a Prometheus scrape target.

--- a/arkouda-helm-charts/arkouda-udp-locale/Chart.yaml
+++ b/arkouda-helm-charts/arkouda-udp-locale/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: arkouda-udp-locale
+description: The arkouda-udp-locale Helm chart
+
+type: application
+
+version: 0.0.1
+
+appVersion: v2023.03.01

--- a/arkouda-helm-charts/arkouda-udp-locale/Chart.yaml
+++ b/arkouda-helm-charts/arkouda-udp-locale/Chart.yaml
@@ -4,6 +4,6 @@ description: The arkouda-udp-locale Helm chart
 
 type: application
 
-version: 0.0.1
+version: 1.0.0
 
-appVersion: v2023.03.01
+appVersion: v2023.04.07

--- a/arkouda-helm-charts/arkouda-udp-locale/README.md
+++ b/arkouda-helm-charts/arkouda-udp-locale/README.md
@@ -8,13 +8,6 @@ The arkouda-udp-locale Helm chart deploys 1..n arkouda-udp-locale docker contain
 
 The arkouda-udp-server Helm deployment is configured within the [values.yaml](values.yaml) file.
 
-### Version
-
-```
-releaseVersion: v2023.03.01
-imagePullPolicy: IfNotPresent
-```
-
 ### Server
 
 The server configuration section sets the number of arkouda-locale containers to startup along with resources as shown below:

--- a/arkouda-helm-charts/arkouda-udp-locale/README.md
+++ b/arkouda-helm-charts/arkouda-udp-locale/README.md
@@ -1,0 +1,53 @@
+# arkouda-udp-locale
+
+## Overview
+
+The arkouda-udp-locale Helm chart deploys 1..n arkouda-udp-locale docker containers that, together with the arkouda-udp-server bootstrap server, compose the Arkouda-on-Kubernetes deployment. The arkouda-udp-locale Helm chart is deployed first and, once all of the arkouda-udp-locale pods are running, the arkouda-udp-server Helm chart is deployed. The arkouda-udp-server container uses ssh to establish a gasnet/udp-managed Arkouda multi-locale instance.
+
+## Configuration
+
+The arkouda-udp-server Helm deployment is configured within the [values.yaml](values.yaml) file.
+
+### Version
+
+```
+releaseVersion: 0.4.5
+imagePullPolicy: IfNotPresent
+```
+
+### Server
+
+The server configuration section sets the number of arkouda-locale containers to startup along with resources as shown below:
+
+```
+server:
+  port: 5555
+  numLocales: 2
+  memTrack: true
+  resources:
+    limits:
+      cpu: 2000m
+      memory: 2048Mi
+    requests:
+      cpu: 2000m
+      memory: 2048Mi
+  threadsPerLocale: 4
+```
+
+### External System
+
+The external section sets the persistence parameters that enable/disable writing to persistent storage:
+
+```
+external:
+  persistence:
+    enabled: true
+    path: /opt/locale
+    hostPath: /mnt/data/arkouda
+```
+
+## Helm Install Command
+
+```
+helm install -n arkouda arkouda-locale arkouda-udp-locale/
+```

--- a/arkouda-helm-charts/arkouda-udp-locale/templates/arkouda-locale-headless-service.yaml
+++ b/arkouda-helm-charts/arkouda-udp-locale/templates/arkouda-locale-headless-service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: arkouda-locale-headless
+  namespace: arkouda
+spec: 
+  clusterIP: None
+  selector:
+    app: arkouda-locale

--- a/arkouda-helm-charts/arkouda-udp-locale/templates/arkouda-locale-ssh-service.yaml
+++ b/arkouda-helm-charts/arkouda-udp-locale/templates/arkouda-locale-ssh-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: arkouda-locale-ssh
+spec:
+  type: ClusterIP
+  ports:
+    - port: 22
+      targetPort: 22
+      protocol: TCP
+  selector:
+    app: arkouda-server

--- a/arkouda-helm-charts/arkouda-udp-locale/templates/arkouda-locale.yaml
+++ b/arkouda-helm-charts/arkouda-udp-locale/templates/arkouda-locale.yaml
@@ -51,10 +51,10 @@ spec:
       volumes:
         - name: ssl
           secret:
-            secretName: arkouda-tls
+            secretName: {{ .Values.secrets.tls }}
         - name: ssh
           secret:
-            secretName: arkouda-ssh
+            secretName: {{ .Values.secrets.ssh }}
         {{- if eq .Values.external.persistence.enabled true }}
         - name: locale
           hostPath:

--- a/arkouda-helm-charts/arkouda-udp-locale/templates/arkouda-locale.yaml
+++ b/arkouda-helm-charts/arkouda-udp-locale/templates/arkouda-locale.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: arkouda-locale
+spec:
+  replicas: {{ .Values.server.numLocales }}
+  selector:
+    matchLabels:
+      app: arkouda-locale
+  template:
+    metadata:
+      labels:
+        app: arkouda-locale
+        name: arkouda-locale
+    spec:
+      containers:
+        - name: arkouda-locale
+          image: {{ .Values.imageRepository }}/arkouda-udp-server:{{ .Values.releaseVersion }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          resources:
+            requests:
+              cpu: {{ .Values.server.resources.requests.cpu }}
+              memory: {{ .Values.server.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.server.resources.limits.cpu }}
+              memory: {{ .Values.server.resources.limits.memory }}
+          command: [ "sh", "/opt/arkouda/start-arkouda-locale.sh" ]
+          ports:
+          - containerPort: 22
+            hostPort: 25
+          volumeMounts:
+          - name: ssl
+            mountPath: "/etc/ssl/arkouda"
+          - name: ssh
+            mountPath: "/home/ubuntu/ssh-keys"
+          {{- if eq .Values.external.persistence.enabled true }}
+          - name: locale
+            mountPath: {{ .Values.external.persistence.path }}
+          {{- end }}
+          env:
+            - name: MY_IP
+              valueFrom:
+                fieldRef: 
+                  fieldPath: status.podIP
+            - name: NUM_LOCALES
+              value: {{ .Values.server.numLocales | quote }}
+            - name: MEMTRACK
+              value: {{ .Values.server.memTrack | quote }}
+            - name: CHPL_RT_NUM_THREADS_PER_LOCALE
+              value: {{ .Values.server.threadsPerLocale | quote }} 
+      volumes:
+        - name: ssl
+          secret:
+            secretName: arkouda-server
+        - name: ssh
+          secret:
+            secretName: arkouda-ssh
+        {{- if eq .Values.external.persistence.enabled true }}
+        - name: locale
+          hostPath:
+            path: {{ .Values.external.persistence.hostPath }}
+        {{- end }}  

--- a/arkouda-helm-charts/arkouda-udp-locale/values.yaml
+++ b/arkouda-helm-charts/arkouda-udp-locale/values.yaml
@@ -1,0 +1,29 @@
+# Default values for arkouda-udp-locale chart
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+######################## Pod Settings ########################
+
+imageRepository: bearsrus
+releaseVersion: v2023.03.01
+imagePullPolicy: IfNotPresent
+
+################ Arkouda Locale Configuration ################
+
+server: 
+  port: 5555
+  numLocales: 2
+  memTrack: true
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1024Mi
+    requests:
+      cpu: 1000m
+      memory: 1024Mi
+  threadsPerLocale: 4
+external:
+  persistence: 
+    enabled: false
+    path: /opt/locale
+    hostPath:

--- a/arkouda-helm-charts/arkouda-udp-locale/values.yaml
+++ b/arkouda-helm-charts/arkouda-udp-locale/values.yaml
@@ -1,18 +1,16 @@
-# Default values for arkouda-udp-locale chart
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+# Default values for the arkouda-udp-locale chart
 
 ######################## Pod Settings ########################
 
 imageRepository: bearsrus
-releaseVersion: v2023.03.01
+releaseVersion: v2023.04.07
 imagePullPolicy: IfNotPresent
 
 ################ Arkouda Locale Configuration ################
 
 server: 
-  port: 5555
-  numLocales: 2
+  port: # Arkouda port, defaults to 5555
+  numLocales: # number of arkouda-udp-locale pods
   memTrack: true
   resources:
     limits:
@@ -21,9 +19,13 @@ server:
     requests:
       cpu: 1000m
       memory: 1024Mi
-  threadsPerLocale: 4
+  threadsPerLocale: # number of CPU cores for each locale
 external:
   persistence: 
     enabled: false
     path: /opt/locale
     hostPath:
+secrets:
+  tls: # name of tls secret used to access Kubernetes API
+  ssh: # name of ssh secret used to launch Arkouda locales
+

--- a/arkouda-helm-charts/arkouda-udp-server/Chart.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: arkouda-udp-server
+description: The arkouda-udp-server Helm chart
+
+type: application
+
+version: 0.0.1
+
+appVersion: v2023.03.01
+

--- a/arkouda-helm-charts/arkouda-udp-server/Chart.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/Chart.yaml
@@ -4,7 +4,7 @@ description: The arkouda-udp-server Helm chart
 
 type: application
 
-version: 0.0.1
+version: 1.0.0
 
-appVersion: v2023.03.01
+appVersion: v2023.04.07
 

--- a/arkouda-helm-charts/arkouda-udp-server/README.md
+++ b/arkouda-helm-charts/arkouda-udp-server/README.md
@@ -155,7 +155,7 @@ The arkouda-udp-server Helm deployment is configured within the [values.yaml](va
 
 ### values.yaml
 
-#### Server
+#### server
 
 ```
 server:
@@ -180,7 +180,7 @@ server:
       targetPort: # k8s targetPort mapping to the Arkouda metrics port, defaults to 5556
 ```
 
-#### External System
+#### external
 
 ```
 external:
@@ -198,10 +198,9 @@ external:
     targetPort: # k8s service targetPort Arkouda will register, defaults to 5555
 ```
 
-#### Metrics Server
+#### metricsExporter
 
-The metricsServer section configures the embedded prometheus-arkouda-exporter which is deployed
-if server.metrics.collectMetrics = true.
+The metricsExporter section configures the embedded prometheus-arkouda-exporter which is deployed if server.metrics.collectMetrics = true.
 
 ```
 metricsExporter:
@@ -212,28 +211,13 @@ metricsExporter:
     name: # prometheus-arkouda-exporter service name
     port: # prometheus-arkouda-exporter service port, defaults to 5080
   pollingIntervalSeconds: 5
-  dynamicScrapeTarget: true
 ```
 
-## Prometheus Configuration
-
-Prometheus is configured manually its prometheus.yaml file, the Prometheus [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md#deploying-a-sample-application), or [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md#using-podmonitors). ServiceMonitor and/or PodMonitor configuration(s) will be added soon to the arkouda-udp-server deployment. 
-
-In the meantime, adding the prometheus-arkouda-exporter as a scrape target to the prometheus.yaml is as follows: 
-
-Within the static_config section, add an entry for the prometheus-arkouda-exporter container:
-```
-    scrape_configs:
-      - job_name: # desired prometheus scrape target job name
-        static_configs:
-          - targets:
-            - metricsExporter.service.name.arkoudaNamespace:metricsExporter.service.port
-            labels:
-              arkouda_instance: # desired Arkouda instance name
-              launch_method: Kubernetes
-```
+The prometheus-arkouda-exporter registers as a Prometheus scrape target via the Prometheus [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md).
 
 ## Helm Install Command
+
+An example Helm install command is shown below:
 
 ```
 helm install -n arkouda arkouda-server arkouda-udp-server/

--- a/arkouda-helm-charts/arkouda-udp-server/README.md
+++ b/arkouda-helm-charts/arkouda-udp-server/README.md
@@ -1,0 +1,217 @@
+# arkouda-udp-server
+
+## Overview
+
+The arkouda-udp-server Helm chart deploys the containerized Arkouda server (locale 0) instance that bootstraps a multi-locale Arkouda cluster that communicates via gasnet/udp. 
+
+## Arkouda-on-Kubernetes API Pre-requisites
+
+arkouda-udp-server generates GASNET udp connections with all previously-deployed arkouda-udp-locale pods, registers itself as a service, and creates a Prometheus scrape target via Kubernetes API CRUD operations. Accordingly, the following Kubernetes artifacts are required:
+
+1. User that is to be bound to the requisite ClusterRoles
+2. Secret composed of the .key and .crt files used to create the arkouda user
+3. ClusterRoles with permissions to enable Kubernetes API requests
+4. ClusterRoleBindings that bind the ClusterRoles to the Kubernetes user
+
+### Kubernetes User
+
+The workflow for creating an a Kubernetes user that can be bound to Roles/ClusterRoles possessing the required Kubernetes API permissions is as follows:
+
+```
+# Generate base key file
+openssl genrsa -out arkouda.key 2048
+ 
+# User and password generated in this step
+openssl req -new -key arkouda.key -out arkouda.csr
+ 
+# sign with the configured k8s CA
+sudo openssl x509 -req -in arkouda.csr -CA /etc/kubernetes/pki/ca.crt -CAkey /etc/kubernetes/pki/ca.key -CAcreateserial -out arkouda.crt -days 730
+
+# Create the arkouda user with the generated credentials
+kubectl config set-credentials arkouda --client-certificate=arkouda.crt --client-key=arkouda.key
+
+```
+
+Note: the cert CN is the Kubernetes user name
+
+### Kubernetes Secret
+
+The .key and .crt files created above are used to create a Kubernetes secret, which is used to connect to the Kubernetes API and load permissions from the Roles and/or ClusterRoles bound to the user. Important note: the secret must be deployed to the same namespace arkouda-udp-server and arkouda-udp-locale are deployed.
+
+An example Kubernetes secret create command is as follows:
+
+```
+kubectl create secret tls arkouda --cert=arkouda.crt --key=arkouda.key -n arkouda
+```
+
+### ClusterRole
+
+The Kubernetes API permissions are in the form of a ClusterRole (scoped to all namespaces). For the purposes of this demonstration, the ClusterRoles are as follows. Corresponding Role definitions only differ in that that the Kind field is Role and metadata has a namespace element.
+
+#### GASNET udp Integration
+
+The arkouda-udp-server deployment discovers all arkouda-udp-locale pods on startup to create the GASNET udp connections between all Arkouda locales. Accordingly, Arkouda requires Kubernetes pod list and get permissions. The corresponding ClusterRole is as follows:
+
+```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pod-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+```
+
+This ClusterRole is bound to the arkouda Kubernetes user as follows:
+
+```
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: arkouda-service-configmap-update-patch
+subjects:
+- kind: User
+  name: arkouda
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io
+```
+
+#### Service Integration
+
+Arkouda-on-Kubernetes integrates with Kubernetes service discovery by creating a Kubernetes service upon arkouda-udp-server startup and deleting the Kubernetes service upon teardown. Consequently, Arkouda-on-Kubernetes requires full Kubernetes service CRUD permissions to enable service discovery. The corresponding ClusterRole is as follows:
+
+```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: service-endpoints-crud
+rules:
+- apiGroups: [""]
+  resources: ["services","endpoints"]
+  verbs: ["get","watch","list","create","delete","update"]
+```
+
+This ClusterRole is bound to the arkouda Kubernetes user as follows:
+
+```
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: arkouda-service-endpoints-crud
+subjects:
+- kind: User
+  name: arkouda
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: service-endpoints-crud
+  apiGroup: rbac.authorization.k8s.io
+```
+
+#### Metrics Integration
+
+Arkouda utilizes the prometheus-arkouda-exporter to provide Prometheus metrics export capabilities. prometheus-arkouda-exporter registers as a dynamic scrape target for Prometheus, a process which  entails adding/deleting scrape targets to/from the Prometheus server ConfigMap. Accordingly, Arkouda requires update and patch permissions for Kubernetes ConfigMaps. The corresponding ClusterRole is as follows:
+
+```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-configmap-updater
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get","patch","update"]
+``` 
+
+This ClusterRole is bound to the arkouda Kubernetes user as follows:
+
+```
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: arkouda-prometheus-configmap-updater
+subjects:
+- kind: User
+  name: arkouda
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: prometheus-configmap-updater
+  apiGroup: rbac.authorization.k8s.io
+```
+
+## Configuration
+
+The arkouda-udp-server Helm deployment is configured within the [values.yaml](values.yaml) as well as the [scrape target values.yaml](charts/dynamic-scrape-target) file, the latter of which is required when metrics capture and dynamic Prometheus scrape target are both enabled.
+
+### values.yaml
+
+#### Server
+
+```
+server:
+  numLocales: # total number of Arkouda locales = number of arkouda-udp-locale pods + 1
+  authenticate: # whether to require token authentication
+  verbose: # enable verbose logging
+  memTrack: true
+  threadsPerLocale: # number of cpu cores to be used per locale
+  memMax: # maximum bytes of RAM to be used per locale
+  logLevel: LogLevel.INFO
+  service:
+    type: # k8s service type, usually ClusterIP, NodePort, or LoadBalancer
+    port: # service port Arkouda is listening on, defaults to 5555
+    targetPort: # if service tyoe is ClusterIP or LoadBalancer, defaults to 5555
+    nodeport: # if service type is Nodeport
+    name: # service name
+  metrics:
+    collectMetrics: # whether to collect metrics and make them available via  k8s service
+    service:
+      name: # k8s service name for the Arkouda metrics service endpoint
+      port: # k8s service port for the Arkouda metrics service endpoint, defaults to 5556
+      targetPort: # k8s targetPort mapping to the Arkouda metrics port, defaults to 5556
+```
+
+#### External System
+
+```
+external:
+  persistence:
+    enabled: false
+    path: /opt/locale # pod directory path DO NOT CHANGE
+    hostPath: # host machine path
+  certFile: /etc/ssl/arkouda/tls.crt
+  keyFile: /etc/ssl/arkouda/tls.key
+  k8sHost:
+  namespace: # namespace Arkouda will register service
+  service:
+    name: # k8s service name Arkouda will register
+    port: # k8s service port Arkouda will register, defaults to 5555
+    targetPort: # k8s service targetPort Arkouda will register, defaults to 5555
+```
+
+#### Metrics Server
+
+The metricsServer section configures the embedded prometheus-arkouda-exporter which is deployed
+if server.metrics.collectMetrics = true.
+
+```
+metricsExporter:
+  imageRepository: bearsrus
+  releaseVersion: # prometheus-arkouda-exporter release version
+  imagePullPolicy: IfNotPresent
+  service:
+    name: # prometheus-arkouda-exporter service name
+    port: # prometheus-arkouda-exporter service port, defaults to 5080
+  pollingIntervalSeconds: 5
+  dynamicScrapeTarget: true
+```
+
+## Helm Install Command
+
+```
+helm install -n arkouda arkouda-server arkouda-udp-server/
+```

--- a/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-driver.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-driver.yaml
@@ -83,8 +83,6 @@ spec:
               value: {{ .Values.server.verbose | quote }}   
             - name: MEMTRACK
               value: {{ .Values.server.memTrack | quote }}
-            - name: MEMMAX
-              value: {{ .Values.server.memMax | quote }}
             - name: CHPL_RT_NUM_THREADS_PER_LOCALE
               value: {{ .Values.server.threadsPerLocale | quote }}
             - name: GASNET_SUPERNODE_MAXSIZE
@@ -122,10 +120,10 @@ spec:
       volumes:              
         - name: ssl
           secret:
-            secretName: arkouda-server 
+            secretName: {{ .Values.secrets.tls }}
         - name: ssh
           secret:
-            secretName: arkouda-ssh
+            secretName: {{ .Values.secrets.ssh }}
         {{- if eq .Values.external.persistence.enabled true }}
         - name: locale
           hostPath:

--- a/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-driver.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-driver.yaml
@@ -12,11 +12,10 @@ spec:
           image: {{ .Values.metricsExporter.imageRepository }}/prometheus-arkouda-exporter:{{ .Values.metricsExporter.releaseVersion }}
           imagePullPolicy: {{ .Values.metricsExporter.imagePullPolicy }}
           ports:
-          - containerPort: {{ .Values.metricsExporter.service.port }}
-            hostPort: 5080
+          - containerPort: 5080
           env:
             - name: EXPORT_PORT
-              value: {{ .Values.metricsExporter.port | quote}}
+              value: "5080"
             - name: POLLING_INTERVAL_SECONDS
               value: {{ .Values.metricsExporter.pollingIntervalSeconds | quote}}
             - name: ARKOUDA_SERVER_NAME

--- a/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-driver.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-driver.yaml
@@ -1,0 +1,140 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: arkouda-server
+  labels: 
+    app: arkouda-server
+spec:
+      restartPolicy: Never
+      containers:
+        {{- if eq .Values.server.metrics.collectMetrics true }}
+        - name: arkouda-metrics-server
+          image: {{ .Values.metricsExporter.imageRepository }}/prometheus-arkouda-exporter:{{ .Values.metricsExporter.releaseVersion }}
+          imagePullPolicy: {{ .Values.metricsExporter.imagePullPolicy }}
+          ports:
+          - containerPort: {{ .Values.metricsExporter.service.port }}
+            hostPort: 5080
+          env:
+            - name: EXPORT_PORT
+              value: {{ .Values.metricsExporter.port | quote}}
+            - name: POLLING_INTERVAL_SECONDS
+              value: {{ .Values.metricsExporter.pollingIntervalSeconds | quote}}
+            - name: ARKOUDA_SERVER_NAME
+              value: {{ .Values.metricsExporter.service.name | quote}}
+            - name: ARKOUDA_METRICS_SERVICE_HOST
+              value: {{ .Values.server.metrics.service.name | quote}}
+            - name: ARKOUDA_METRICS_SERVICE_PORT
+              value: {{ .Values.server.metrics.service.port | quote}}
+        {{- end }}
+        - name: arkouda-server
+          image: {{ .Values.imageRepository }}/arkouda-udp-server:{{ .Values.releaseVersion }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command: [ "sh", "/opt/arkouda/start-arkouda-server.sh" ]
+          lifecycle:
+            preStop:
+              exec:
+              {{- if eq .Values.server.metrics.collectMetrics true }}
+                command: ['python3','-c', 'import os; service=os.environ["EXTERNAL_SERVICE_NAME"]; metricsService=os.environ["METRICS_SERVICE_NAME"]; namespace=os.environ["NAMESPACE"]; from arkouda_integration.k8s import KubernetesDao; dao = KubernetesDao(cert_file=os.environ["CERT_FILE"],key_file=os.environ["KEY_FILE"],k8s_host=os.environ["K8S_HOST"]); dao.delete_service(service_name=service,namespace=namespace); dao.delete_service(service_name=metricsService,namespace=namespace)']
+              {{ else }}
+                command: ['python3','-c', 'import os; service=os.environ["EXTERNAL_SERVICE_NAME"]; namespace=os.environ["NAMESPACE"]; from arkouda_integration.k8s import KubernetesDao; dao = KubernetesDao(cert_file=os.environ["CERT_FILE"],key_file=os.environ["KEY_FILE"],k8s_host=os.environ["K8S_HOST"]); dao.delete_service(service_name=service,namespace=namespace)']
+              {{- end }}
+          resources:
+            requests:
+              cpu: {{ .Values.resources.requests.cpu }}
+              memory: {{ .Values.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.resources.limits.cpu }}
+              memory: {{ .Values.resources.limits.memory }}
+          ports:
+          - containerPort: {{ .Values.server.service.port }}
+            hostPort: 5555
+          - containerPort: 22
+            hostPort: 25
+          volumeMounts:
+          - name: ssl
+            mountPath: "/etc/ssl/arkouda"
+          - name: ssh
+            mountPath: "/home/ubuntu/ssh-keys"
+          {{- if eq .Values.external.persistence.enabled true }}
+          - name: locale
+            mountPath: {{ .Values.external.persistence.path }}
+          {{- end }}
+          - name: arkouda-server-launch-script
+            mountPath: /opt/arkouda/start-arkouda-server.sh
+            subPath: start-arkouda-server.sh
+          env:
+            - name: MY_IP
+              valueFrom:
+                fieldRef: 
+                  fieldPath: status.podIP
+            - name: GASNET_MASTERIP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: NUMLOCALES
+              value: {{ .Values.server.numLocales | quote}}
+            - name: SSH_SERVERS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: AUTHENTICATE
+              value: {{ .Values.server.authenticate | quote}} 
+            - name: VERBOSE
+              value: {{ .Values.server.verbose | quote }}   
+            - name: MEMTRACK
+              value: {{ .Values.server.memTrack | quote }}
+            - name: MEMMAX
+              value: {{ .Values.server.memMax | quote }}
+            - name: CHPL_RT_NUM_THREADS_PER_LOCALE
+              value: {{ .Values.server.threadsPerLocale | quote }}
+            - name: GASNET_SUPERNODE_MAXSIZE
+              value: '1' 
+            - name: CERT_FILE
+              value: {{ .Values.external.certFile | quote }}
+            - name: KEY_FILE
+              value: {{ .Values.external.keyFile | quote }}
+            - name: K8S_HOST
+              value: {{ .Values.external.k8sHost | quote }} 
+            - name: NAMESPACE
+              value: {{ .Values.external.namespace }}
+            - name: APP_NAME
+              value: {{ .Values.locale.appName | quote }}
+            - name: ARKOUDA_CLIENT_MODE
+              value: API
+            - name: POD_METHOD
+              value: {{ .Values.locale.podMethod | quote }}
+            - name: EXTERNAL_SERVICE_NAME
+              value: {{ .Values.external.service.name | quote }}
+            - name: EXTERNAL_SERVICE_PORT
+              value: {{ .Values.external.service.port | quote }}
+            - name: EXTERNAL_SERVICE_TARGET_PORT
+              value: {{ .Values.external.service.targetPort | quote }}
+            - name: LOG_LEVEL  
+              value: {{ .Values.server.logLevel }}    
+            - name: COLLECT_METRICS
+              value: {{ .Values.server.metrics.collectMetrics | quote }}
+            - name: METRICS_SERVICE_NAME
+              value: {{ .Values.server.metrics.service.name }}
+            - name: METRICS_SERVICE_PORT
+              value: {{ .Values.server.metrics.service.port | quote }}
+            - name: METRICS_SERVICE_TARGET_PORT
+              value: {{ .Values.server.metrics.service.targetPort | quote }}
+      volumes:              
+        - name: ssl
+          secret:
+            secretName: arkouda-server 
+        - name: ssh
+          secret:
+            secretName: arkouda-ssh
+        {{- if eq .Values.external.persistence.enabled true }}
+        - name: locale
+          hostPath:
+            path: {{ .Values.external.persistence.hostPath }}
+        {{- end }}
+        - name: arkouda-server-launch-script
+          configMap:
+            name: arkouda-server-launch-script
+            items:
+             - key: script
+               path: start-arkouda-server.sh
+

--- a/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-metrics-exporter-service.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-metrics-exporter-service.yaml
@@ -2,11 +2,16 @@ apiVersion: v1
 kind: Service
 metadata:
   name: arkouda-metrics-exporter
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "{{ .Values.metricsExporter.service.port }}"
+    prometheus.io/scrape: "true"
+
 spec:
   type: ClusterIP
   ports:
     - port: {{ .Values.metricsExporter.service.port }}
-      targetPort: {{ .Values.metricsExporter.service.port }}
+      targetPort: 5080
       protocol: TCP
   selector:
     app: arkouda-server

--- a/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-metrics-exporter-service.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-metrics-exporter-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: arkouda-metrics-exporter
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.metricsExporter.service.port }}
+      targetPort: {{ .Values.metricsExporter.service.port }}
+      protocol: TCP
+  selector:
+    app: arkouda-server

--- a/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-server-headless-service.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-server-headless-service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: arkouda-headless-service
+  namespace: arkouda
+spec: 
+  clusterIP: None
+  selector:
+    app: arkouda-server

--- a/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-server-launch-script-config-map.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-server-launch-script-config-map.yaml
@@ -19,7 +19,7 @@ data:
 
      cat ~/.ssh/id_rsa.pub > ~/.ssh/authorized_keys
 
-     export LOCALE_IPS="$(python3 /opt/arkouda-contrib/arkouda_integration/client/scripts/pods.py '-c=$CERT_FILE' '-k=$KEY_FILE' '-kh=$K8S_HOST' '-i=GET_POD_IPS' '-n=arkouda' '-a=arkouda-locale')"
+     export LOCALE_IPS="$(python3 /opt/arkouda-contrib/arkouda_integration/client/scripts/pods.py '-c=$CERT_FILE' '-k=$KEY_FILE' '-kh=$K8S_HOST' '-i=GET_POD_IPS' '-n=$NAMESPACE' '-a=$APP_NAME')"
      export SSH_SERVERS="$MY_IP $LOCALE_IPS"
 
      {{- if eq .Values.server.metrics.collectMetrics true }}

--- a/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-server-launch-script-config-map.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-server-launch-script-config-map.yaml
@@ -1,0 +1,35 @@
+---
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: arkouda-server-launch-script
+  labels:
+    name: arkouda-server-launch-script
+data:
+  script: |-
+  
+     #!/bin/bash
+     sudo service ssh start
+
+     mkdir ~/.ssh/
+     sudo cp ~/ssh-keys/id_rsa* ~/.ssh/
+     sudo chown -R ubuntu:ubuntu ~/.ssh/*
+     chmod -R 600 ~/.ssh/*
+
+     cat ~/.ssh/id_rsa.pub > ~/.ssh/authorized_keys
+
+     export LOCALE_IPS="$(python3 /opt/arkouda-contrib/arkouda_integration/client/scripts/pods.py '-c=$CERT_FILE' '-k=$KEY_FILE' '-kh=$K8S_HOST' '-i=GET_POD_IPS' '-n=arkouda' '-a=arkouda-locale')"
+     export SSH_SERVERS="$MY_IP $LOCALE_IPS"
+
+     {{- if eq .Values.server.metrics.collectMetrics true }}
+     /opt/arkouda/arkouda_server -nl ${NUMLOCALES:-1} --ExternalIntegration.systemType=SystemType.KUBERNETES \
+                                                      --ServerDaemon.daemonTypes=ServerDaemonType.INTEGRATION,ServerDaemonType.METRICS \
+                                                      --memTrack=${MEMTRACK:-true} --authenticate=${AUTHENTICATE:-false} \
+                                                      --logLevel=${LOG_LEVEL:-LogLevel.INFO} --memMax=${MEMMAX:-1073741824}
+     {{- else }}
+     /opt/arkouda/arkouda_server -nl ${NUMLOCALES:-1} --ExternalIntegration.systemType=SystemType.KUBERNETES \
+                                                      --ServerDaemon.daemonTypes=ServerDaemonType.INTEGRATION \
+                                                      --memTrack=${MEMTRACK:-true} --authenticate=${AUTHENTICATE:-false} \
+                                                      --logLevel=${LOG_LEVEL:-LogLevel.INFO} --memMax=${MEMMAX:-1073741824}
+     {{- end }}

--- a/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-server-launch-script-config-map.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-server-launch-script-config-map.yaml
@@ -26,10 +26,10 @@ data:
      /opt/arkouda/arkouda_server -nl ${NUMLOCALES:-1} --ExternalIntegration.systemType=SystemType.KUBERNETES \
                                                       --ServerDaemon.daemonTypes=ServerDaemonType.INTEGRATION,ServerDaemonType.METRICS \
                                                       --memTrack=${MEMTRACK:-true} --authenticate=${AUTHENTICATE:-false} \
-                                                      --logLevel=${LOG_LEVEL:-LogLevel.INFO} --memMax=${MEMMAX:-1073741824}
+                                                      --logLevel=${LOG_LEVEL:-LogLevel.INFO} --memMax={{ .Values.server.memMax | int }}
      {{- else }}
      /opt/arkouda/arkouda_server -nl ${NUMLOCALES:-1} --ExternalIntegration.systemType=SystemType.KUBERNETES \
                                                       --ServerDaemon.daemonTypes=ServerDaemonType.INTEGRATION \
                                                       --memTrack=${MEMTRACK:-true} --authenticate=${AUTHENTICATE:-false} \
-                                                      --logLevel=${LOG_LEVEL:-LogLevel.INFO} --memMax=${MEMMAX:-1073741824}
+                                                      --logLevel=${LOG_LEVEL:-LogLevel.INFO} --memMax={{ .Values.server.memMax | int }}
      {{- end }}

--- a/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-server-ssh-service.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/templates/arkouda-server-ssh-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: arkouda-server-ssh
+spec:
+  type: ClusterIP
+  ports:
+    - port: 22
+      targetPort: 22
+      protocol: TCP
+  selector:
+    app: arkouda-server

--- a/arkouda-helm-charts/arkouda-udp-server/values.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/values.yaml
@@ -1,6 +1,4 @@
-# Default values for arkouda-server-chart.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+# Default values for arkouda-udp-server chart.
 
 resources:
   limits:
@@ -13,7 +11,7 @@ resources:
 ######################## Pod Settings ########################
 
 imageRepository: bearsrus
-releaseVersion: v2023.03.01
+releaseVersion: v2023.04.07
 imagePullPolicy: IfNotPresent
 
 ################ Arkouda Server Configuration ################
@@ -48,7 +46,7 @@ external:
     hostPath: # host machine path
   certFile: /etc/ssl/arkouda/tls.crt
   keyFile: /etc/ssl/arkouda/tls.key
-  k8sHost: 
+  k8sHost: # Kubernetes API url (result of kubectl cluster-info command) 
   namespace: # namespace Arkouda will register service
   service: 
     name: # k8s service name Arkouda will register
@@ -63,3 +61,7 @@ metricsExporter:
     port: # prometheus-arkouda-exporter service port, defaults to 5080
   pollingIntervalSeconds: 5
   dynamicScrapeTarget: true
+secrets:
+  tls: # name of tls secret used to access Kubernetes API
+  ssh: # name of ssh secret used to launch Arkouda locales
+

--- a/arkouda-helm-charts/arkouda-udp-server/values.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/values.yaml
@@ -27,7 +27,6 @@ server:
   service:
     type: # k8s service type, usually ClusterIP, NodePort, or LoadBalancer
     port: # service port Arkouda is listening on, defaults to 5555
-    targetPort: # if service tyoe is ClusterIP or LoadBalancer, defaults to 5555
     nodeport: # if service type is Nodeport
     name: # service name
   metrics:
@@ -35,7 +34,6 @@ server:
     service:
       name: # k8s service name for the Arkouda metrics service endpoint
       port: # k8s service port for the Arkouda metrics service endpoint, defaults to 5556
-      targetPort: # k8s targetPort mapping to the Arkouda metrics port, defaults to 5556
 locale:
   appName: arkouda-locale
   podMethod: GET_POD_IPS
@@ -51,7 +49,6 @@ external:
   service: 
     name: # k8s service name Arkouda will register
     port: # k8s service port Arkouda will register, defaults to 5555
-    targetPort: # k8s service targetPort Arkouda will register, defaults to 5555
 metricsExporter:
   imageRepository: bearsrus
   releaseVersion: # prometheus-arkouda-exporter release version
@@ -60,7 +57,6 @@ metricsExporter:
     name: # prometheus-arkouda-exporter service name
     port: # prometheus-arkouda-exporter service port, defaults to 5080
   pollingIntervalSeconds: 5
-  dynamicScrapeTarget: true
 secrets:
   tls: # name of tls secret used to access Kubernetes API
   ssh: # name of ssh secret used to launch Arkouda locales

--- a/arkouda-helm-charts/arkouda-udp-server/values.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/values.yaml
@@ -1,0 +1,65 @@
+# Default values for arkouda-server-chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1024Mi
+  requests:
+    cpu: 1000m
+    memory: 1024Mi
+
+######################## Pod Settings ########################
+
+imageRepository: bearsrus
+releaseVersion: v2023.03.01
+imagePullPolicy: IfNotPresent
+
+################ Arkouda Server Configuration ################
+
+server: 
+  numLocales: # total number of Arkouda locales = number of arkouda-udp-locale pods + 1
+  authenticate: # whether to require token authentication
+  verbose: # enable verbose logging
+  memTrack: true
+  threadsPerLocale: # number of cpu cores to be used per locale
+  memMax: # maximum bytes of RAM to be used per locale
+  logLevel: LogLevel.INFO
+  service:
+    type: # k8s service type, usually ClusterIP, NodePort, or LoadBalancer
+    port: # service port Arkouda is listening on, defaults to 5555
+    targetPort: # if service tyoe is ClusterIP or LoadBalancer, defaults to 5555
+    nodeport: # if service type is Nodeport
+    name: # service name
+  metrics:
+    collectMetrics: # whether to collect metrics and make them available via  k8s service
+    service:
+      name: # k8s service name for the Arkouda metrics service endpoint
+      port: # k8s service port for the Arkouda metrics service endpoint, defaults to 5556
+      targetPort: # k8s targetPort mapping to the Arkouda metrics port, defaults to 5556
+locale:
+  appName: arkouda-locale
+  podMethod: GET_POD_IPS
+external:
+  persistence:
+    enabled: false
+    path: /opt/locale # pod directory path DO NOT CHANGE
+    hostPath: # host machine path
+  certFile: /etc/ssl/arkouda/tls.crt
+  keyFile: /etc/ssl/arkouda/tls.key
+  k8sHost: 
+  namespace: # namespace Arkouda will register service
+  service: 
+    name: # k8s service name Arkouda will register
+    port: # k8s service port Arkouda will register, defaults to 5555
+    targetPort: # k8s service targetPort Arkouda will register, defaults to 5555
+metricsExporter:
+  imageRepository: bearsrus
+  releaseVersion: # prometheus-arkouda-exporter release version
+  imagePullPolicy: IfNotPresent
+  service:
+    name: # prometheus-arkouda-exporter service name
+    port: # prometheus-arkouda-exporter service port, defaults to 5080
+  pollingIntervalSeconds: 5
+  dynamicScrapeTarget: true

--- a/arkouda-helm-charts/prometheus-arkouda-exporter/Chart.yaml
+++ b/arkouda-helm-charts/prometheus-arkouda-exporter/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: prometheus-arkouda-exporter
+description: The prometheus-arkouda-exporter Helm chart
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v2023.04.07"

--- a/arkouda-helm-charts/prometheus-arkouda-exporter/README.md
+++ b/arkouda-helm-charts/prometheus-arkouda-exporter/README.md
@@ -1,0 +1,59 @@
+# prometheus-arkouda-exporter
+
+## Configuration
+
+### Arkouda Metrics Server Configuration
+
+The arkouda.metrics section configures the Arkouda instance the prometheus-arkouda-exporter will pull metrics from:
+
+```
+arkouda:
+  metrics:
+    server:
+      name: external-arkouda # maps to arkouda_server_name Prometheus label
+      namespace: arkouda # Arkouda service deployment namespace
+    service:
+      name: # <Arkouda metrics service name>.<Arkouda deployment namespace>
+      port: # Arkouda metrics port, defaults to 5556
+```
+
+### Prometheus Arkouda Exporter Configuration
+
+```
+exporter:
+  server:
+    appName: external-arkouda-metrics-server # prometheus-arkouda-exporter k8s app name
+    pollingIntervalSeconds: 5 # polling interval
+  service:
+    name: # prometheus-arkouda-exporter k8s service name
+    port: 5080 # prometheus-arkouda-exporter k8s service port
+```
+
+### Prometheus 
+
+Prometheus is configured manually its prometheus.yaml file, the Prometheus [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md#deploying-a-sample-application), or [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md#using-podmonitors). ServiceMonitor and/or PodMonitor configuration(s) will be added soon to the arkouda-udp-server deployment.
+
+In the meantime, adding the prometheus-arkouda-exporter as a scrape target to the prometheus.yaml is as follows:
+
+Within the static\_config section, add an entry for the prometheus-arkouda-exporter container:
+
+```
+    scrape_configs:
+      - job_name: # desired prometheus scrape target job name
+        static_configs:
+          - targets:
+            - metricsExporter.service.name.metricsExporter.namespace:metricsExporter.service.port
+            labels:
+              arkouda_instance: # Arkouda target service name
+              launch_method: # Arkouda launch method, either Slurm or Kubernetes
+```
+
+
+## Helm Install Command
+
+An example helm install is as follows. Again, the namespace prometheus-arkouda-exporter is deployed to _must match the namespace the API secret is deployed in._
+
+```
+ helm install -n arkouda promethues-arkouda-exporter prometheus-arkouda-exporter/
+```
+

--- a/arkouda-helm-charts/prometheus-arkouda-exporter/pae-values.yaml
+++ b/arkouda-helm-charts/prometheus-arkouda-exporter/pae-values.yaml
@@ -1,0 +1,40 @@
+# Default values for prometheus-arkouda-exporter chart.
+
+replicaCount: 1
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+########################## Pod Settings ###########################
+
+releaseVersion: v2023.04.07 # prometheus-arkouda-exporter release version
+imagePullPolicy: IfNotPresent
+
+############ prometheus-arkouda-exporter Configuration ############
+
+arkouda:
+  metrics:
+    server:
+      name: project-a
+      namespace: arkouda # namespace Arkouda is deployed to
+    service:
+      name: arkouda-metrics # Arkouda metrics service endpoint name including namespace
+      port: 5556 # Arkouda metrics service port
+
+exporter:
+  server:
+    appName: pae # prometheus-arkouda-exporter app name (binds service to prometheus-arkouda-exporter)
+    pollingIntervalSeconds: 5
+    namespace: # namespace prometheus-arkouda-exporter is deployed to
+  service:
+    name: project-a-metrics-exporter # prometheus-arkouda-exporter service name (used by Prometheus to scrape)
+    port: 6080 # prometheus-arkouda-exporter service port (used by Prometheus to scrape)

--- a/arkouda-helm-charts/prometheus-arkouda-exporter/templates/deployment.yaml
+++ b/arkouda-helm-charts/prometheus-arkouda-exporter/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.exporter.server.appName }}
+  labels:
+    app: {{ .Values.exporter.server.appName }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.exporter.server.appName }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.exporter.server.appName }}
+    spec:
+      containers:
+        - name: arkouda-metrics-exporter
+          image: bearsrus/prometheus-arkouda-exporter:{{ .Values.releaseVersion }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+          - containerPort: 5080
+          env:
+            - name: EXPORT_PORT
+              value: {{ .Values.exporter.service.port | quote }}
+            - name: ARKOUDA_SERVER_NAME
+              value: {{ .Values.arkouda.metrics.server.name | quote }}
+            - name: POLLING_INTERVAL_SECONDS
+              value: {{ .Values.exporter.server.pollingIntervalSeconds | quote }}
+            - name: ARKOUDA_METRICS_SERVICE_HOST
+              value: {{ .Values.arkouda.metrics.service.name | quote }}
+            - name: ARKOUDA_METRICS_SERVICE_PORT
+              value: {{ .Values.arkouda.metrics.service.port | quote }}
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 5080
+            initialDelaySeconds: 30
+            periodSeconds: 60
+

--- a/arkouda-helm-charts/prometheus-arkouda-exporter/templates/service.yaml
+++ b/arkouda-helm-charts/prometheus-arkouda-exporter/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.exporter.service.name }} 
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.exporter.service.port }}
+      targetPort: 5080
+      protocol: TCP
+  selector:
+    app: {{ .Values.exporter.server.appName }}
+

--- a/arkouda-helm-charts/prometheus-arkouda-exporter/templates/service.yaml
+++ b/arkouda-helm-charts/prometheus-arkouda-exporter/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.exporter.service.name }} 
+  name: {{ .Values.exporter.service.name }}
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "{{ .Values.exporter.service.port }}"
+    prometheus.io/scrape: "true" 
 spec:
   type: ClusterIP
   ports:

--- a/arkouda-helm-charts/prometheus-arkouda-exporter/values.yaml
+++ b/arkouda-helm-charts/prometheus-arkouda-exporter/values.yaml
@@ -1,0 +1,40 @@
+# Default values for prometheus-arkouda-exporter chart.
+
+replicaCount: 1
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+########################## Pod Settings ###########################
+
+releaseVersion: # prometheus-arkouda-exporter release version
+imagePullPolicy: IfNotPresent
+
+############ prometheus-arkouda-exporter Configuration ############
+
+arkouda:
+  metrics:
+    server:
+      name: # Arkouda instance app name
+      namespace: # namespace Arkouda is deployed to
+    service:
+      name: # Arkouda metrics service endpoint name including namespace
+      port: 5556 # Arkouda metrics service port
+
+exporter:
+  server:
+    appName: # prometheus-arkouda-exporter app name (binds service to prometheus-arkouda-exporter)
+    pollingIntervalSeconds: # number of seconds between metrics pulls from Arkouda
+    namespace: # namespace prometheus-arkouda-exporter is deployed to
+  service:
+    name: # prometheus-arkouda-exporter service name (used by Prometheus to scrape)
+    port: # prometheus-arkouda-exporter service port (used by Prometheus to scrape)


### PR DESCRIPTION
Closes #84 

This PR does the following:

1. adds arkouda-udp-locale helm chart that deploys locales 1..n-1
2. adds arkouda-udp-server helm chart that deploys locale 0 and, optionally, prometheus-arkouda-exporter for this arkouda-on-kubernetes instance
3. adds helm chart that deploys prometheus-arkouda-exporter that can pull Arkouda metrics from Arkouda-on-Kubernetes or Arkouda-on-Slurm