### PR TITLE
upgrade arkouda-helm-charts and arkouda-docker to v2023.05.05

### DIFF
--- a/arkouda-docker/README.md
+++ b/arkouda-docker/README.md
@@ -14,9 +14,9 @@ and ipython interface to Arkouda. The arkouda-full-stack image extends bearsrus/
 ```
 # set env variables
 export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.30.0
-export ARKOUDA_BRANCH_NAME=2023.04.07
-export ARKOUDA_DISTRO_NAME=v2023.04.07
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.04.07.zip
+export ARKOUDA_BRANCH_NAME=2023.05.05
+export ARKOUDA_DISTRO_NAME=v2023.05.05
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.05.05.zip
 export ARKOUDA_IMAGE_REPO=bearsrus
 
 docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
@@ -35,7 +35,7 @@ By default arkouda-full-stack launches a jupyter notebook that is accessible via
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2023.04.07
+export ARKOUDA_VERSION=v2023.05.05
 
 docker run -it --rm -p 8888:8888 $ARKOUDA_IMAGE_REPO/arkouda-full-stack:$ARKOUDA_VERSION
 ```
@@ -47,7 +47,7 @@ To mount a directory containing files to be analyzed, execute the following comm
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2023.04.07
+export ARKOUDA_VERSION=v2023.05.05
 export HOST_DIR=/opt/datafiles
 export CONTAINER_DIR=/app/data
 
@@ -63,9 +63,9 @@ command is as follows:
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2023.04.07
+export ARKOUDA_VERSION=v2023.05.05
 
-docker run -it --rm --entrypoint=/opt/start-arkouda-full-stack.sh \
+docker run -it --rm -p 8888:8888 --entrypoint=/opt/arkouda/start-smp-arkouda-full-stack.sh \
                     $ARKOUDA_IMAGE_REPO/arkouda-full-stack:$ARKOUDA_VERSION
 ```
 
@@ -80,9 +80,9 @@ The arkouda-smp-server extends bearsrus/chapel-gasnet-smp to deliver a GASNET sm
 
 ```
 export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.30.0
-export ARKOUDA_DISTRO_NAME=v2023.04.07
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.04.07.zip
-export ARKOUDA_BRANCH_NAME=2023.04.07
+export ARKOUDA_DISTRO_NAME=v2023.05.05
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.05.05.zip
+export ARKOUDA_BRANCH_NAME=2023.05.05
 export ARKOUDA_IMAGE_REPO=bearsrus
 
 docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
@@ -97,7 +97,7 @@ docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2023.04.07
+export ARKOUDA_VERSION=v2023.05.05
 
 docker run -it --rm -p 5555:5555 $ARKOUDA_IMAGE_REPO/arkouda-smp-server:$ARKOUDA_VERSION
 ```
@@ -133,9 +133,9 @@ The arkouda-udp-server image extends bearsrus/chapel-gasnet-udp to deliver a GAS
 
 ```
 export CHAPEL_UDP_IMAGE=bearsrus/chapel-gasnet-udp:1.30.0
-export ARKOUDA_DISTRO_NAME=v2023.04.07
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.04.07.zip
-export ARKOUDA_BRANCH_NAME=2023.04.07
+export ARKOUDA_DISTRO_NAME=v2023.05.05
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.05.05.zip
+export ARKOUDA_BRANCH_NAME=2023.05.05
 export ARKOUDA_INTEGRATION_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda-contrib/archive/refs/heads/main.zip
 export ARKOUDA_INTEGRATION_DISTRO_NAME=main
 export ARKOUDA_IMAGE_REPO=bearsrus
@@ -151,7 +151,7 @@ docker build --build-arg CHAPEL_UDP_IMAGE=$CHAPEL_UDP_IMAGE \
 
 ## Launching arkouda-udp-server
 
-The arkouda-udp-server docker image is designed to be launched on Kubernetes via Helm. The Arkouda-on-Kubernetes deployment will be added to arkouda-contrib in the near future.
+The arkouda-udp-server docker image is designed to be launched on Kubernetes via the bears-r-us [Helm charts](../arkouda-helm-charts).
 
 # prometheus-arkouda-exporter
 
@@ -173,10 +173,10 @@ There are six build arguments passed in to the docker build command:
 An example docker build command sequence is as follows:
 
 ```
-export EXPORTER_VERSION=v2023.04.07
-export ARKOUDA_DISTRO_NAME=v2023.04.07
-export ARKOUDA_BRANCH_NAME=2023.04.07
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.04.07.zip
+export EXPORTER_VERSION=v2023.05.05
+export ARKOUDA_DISTRO_NAME=v2023.05.05
+export ARKOUDA_BRANCH_NAME=2023.05.05
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.05.05.zip
 export ARKOUDA_CONTRIB_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda-contrib/archive/refs/heads/main.zip
 export ARKOUDA_CONTRIB_DISTRO_NAME=main
 
@@ -186,7 +186,7 @@ docker build --build-arg ARKOUDA_DISTRO_NAME=$ARKOUDA_DISTRO_NAME --build-arg AR
 ## Running prometheus-arkouda-exporter
 
 ```
-export EXPORTER_VERSION=v2023.04.07
+export EXPORTER_VERSION=v2023.05.05
 
 docker run -e ARKOUDA_METRICS_SERVICE_NAME=localhost -e ARKOUDA_METRICS_SERVICE_PORT=5556 -e POLLING_INTERVAL_SECONDS=5 -e EXPORT_PORT=5080 -e EXPORT_PORT=5080 -p 5080:5080 bearsrus/prometheus-arkouda-exporter:$EXPORTER_VERSION
 
@@ -230,7 +230,7 @@ Shown below are example build commands. To ensure the optimal, respective perfor
 ### arkouda-full-stack
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.04.07 --chapel_version=1.30.0 --image_type=arkouda-full-stack
+python build_docker_image.py --arkouda_tag=v2023.05.05 --chapel_version=1.30.0 --image_type=arkouda-full-stack
 ```
 
 ### chapel-gasnet-smp
@@ -242,7 +242,7 @@ python build_docker_image.py --chapel_version=1.30.0 --image_type=chapel-gasnet-
 ### arkouda-smp-server
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.04.07 --chapel_version=1.30.0 --image_type=arkouda-smp-server
+python build_docker_image.py --arkouda_tag=v2023.05.05 --chapel_version=1.30.0 --image_type=arkouda-smp-server
 ```
 
 ### chapel-gasnet-udp
@@ -254,12 +254,12 @@ python build_docker_image.py --chapel_version=1.30.0 --image_type=chapel-gasnet-
 ### arkouda-udp-server
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.04.07 --chapel_version=1.30.0 --image_type=arkouda-udp-server
+python build_docker_image.py --arkouda_tag=v2023.05.05 --chapel_version=1.30.0 --image_type=arkouda-udp-server
 ```
 
 ### prometheus-arkouda-exporter
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.04.07 --image_type=prometheus-arkouda-exporter
+python build_docker_image.py --arkouda_tag=v2023.05.05 --image_type=prometheus-arkouda-exporter
 ```
 

--- a/arkouda-helm-charts/arkouda-udp-locale/Chart.yaml
+++ b/arkouda-helm-charts/arkouda-udp-locale/Chart.yaml
@@ -4,6 +4,6 @@ description: The arkouda-udp-locale Helm chart
 
 type: application
 
-version: 1.0.0
+version: 1.1.0
 
 appVersion: v2023.05.05

--- a/arkouda-helm-charts/arkouda-udp-locale/Chart.yaml
+++ b/arkouda-helm-charts/arkouda-udp-locale/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 
 version: 1.0.0
 
-appVersion: v2023.04.07
+appVersion: v2023.05.05

--- a/arkouda-helm-charts/arkouda-udp-locale/README.md
+++ b/arkouda-helm-charts/arkouda-udp-locale/README.md
@@ -35,7 +35,7 @@ The external section sets the persistence parameters that enable/disable writing
 external:
   persistence:
     enabled: true
-    path: /opt/locale
+    path: /arkouda-files
     hostPath: /mnt/data/arkouda
 ```
 

--- a/arkouda-helm-charts/arkouda-udp-locale/templates/deployment.yaml
+++ b/arkouda-helm-charts/arkouda-udp-locale/templates/deployment.yaml
@@ -18,12 +18,7 @@ spec:
           image: {{ .Values.imageRepository }}/arkouda-udp-server:{{ .Values.releaseVersion }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           resources:
-            requests:
-              cpu: {{ .Values.server.resources.requests.cpu }}
-              memory: {{ .Values.server.resources.requests.memory }}
-            limits:
-              cpu: {{ .Values.server.resources.limits.cpu }}
-              memory: {{ .Values.server.resources.limits.memory }}
+            {{- toYaml .Values.resources | nindent 12 }}
           command: [ "sh", "/opt/arkouda/start-arkouda-locale.sh" ]
           ports:
           - containerPort: 22

--- a/arkouda-helm-charts/arkouda-udp-locale/templates/deployment.yaml
+++ b/arkouda-helm-charts/arkouda-udp-locale/templates/deployment.yaml
@@ -22,7 +22,6 @@ spec:
           command: [ "sh", "/opt/arkouda/start-arkouda-locale.sh" ]
           ports:
           - containerPort: 22
-            hostPort: 25
           volumeMounts:
           - name: ssl
             mountPath: "/etc/ssl/arkouda"

--- a/arkouda-helm-charts/arkouda-udp-locale/values.yaml
+++ b/arkouda-helm-charts/arkouda-udp-locale/values.yaml
@@ -1,6 +1,4 @@
 # Default values for arkouda-udp-locale chart
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
 
 ######################## Pod Settings ########################
 

--- a/arkouda-helm-charts/arkouda-udp-locale/values.yaml
+++ b/arkouda-helm-charts/arkouda-udp-locale/values.yaml
@@ -1,31 +1,33 @@
-# Default values for the arkouda-udp-locale chart
+# Default values for arkouda-udp-locale chart
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
 
 ######################## Pod Settings ########################
 
 imageRepository: bearsrus
-releaseVersion: v2023.04.07
+releaseVersion: v2023.05.05
 imagePullPolicy: IfNotPresent
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1024Mi
+  requests:
+    cpu: 1000m
+    memory: 1024Mi
 
 ################ Arkouda Locale Configuration ################
 
 server: 
   port: # Arkouda port, defaults to 5555
-  numLocales: # number of arkouda-udp-locale pods
   memTrack: true
-  resources:
-    limits:
-      cpu: 1000m
-      memory: 1024Mi
-    requests:
-      cpu: 1000m
-      memory: 1024Mi
+  numLocales: # number of arkouda-udp-locale pods
   threadsPerLocale: # number of CPU cores for each locale
 external:
   persistence: 
-    enabled: false
-    path: /opt/locale
-    hostPath:
+    enabled: true
+    path: /arkouda-files # pod directory path, must match arkouda-udp-server 
+    hostPath: # host directory path, must match arkouda-udp-server
 secrets:
   tls: # name of tls secret used to access Kubernetes API
   ssh: # name of ssh secret used to launch Arkouda locales
-

--- a/arkouda-helm-charts/arkouda-udp-server/Chart.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/Chart.yaml
@@ -4,7 +4,7 @@ description: The arkouda-udp-server Helm chart
 
 type: application
 
-version: 1.0.0
+version: 1.1.0
 
-appVersion: v2023.04.07
+appVersion: v2023.05.05
 

--- a/arkouda-helm-charts/arkouda-udp-server/README.md
+++ b/arkouda-helm-charts/arkouda-udp-server/README.md
@@ -169,7 +169,6 @@ server:
   service:
     type: # k8s service type, usually ClusterIP, NodePort, or LoadBalancer
     port: # service port Arkouda is listening on, defaults to 5555
-    targetPort: # if service tyoe is ClusterIP or LoadBalancer, defaults to 5555
     nodeport: # if service type is Nodeport
     name: # service name
   metrics:
@@ -177,7 +176,6 @@ server:
     service:
       name: # k8s service name for the Arkouda metrics service endpoint
       port: # k8s service port for the Arkouda metrics service endpoint, defaults to 5556
-      targetPort: # k8s targetPort mapping to the Arkouda metrics port, defaults to 5556
 ```
 
 #### external
@@ -188,14 +186,11 @@ external:
     enabled: false
     path: /opt/locale # pod directory path DO NOT CHANGE
     hostPath: # host machine path
-  certFile: /etc/ssl/arkouda/tls.crt
-  keyFile: /etc/ssl/arkouda/tls.key
   k8sHost:
   namespace: # namespace Arkouda will register service
   service:
     name: # k8s service name Arkouda will register
     port: # k8s service port Arkouda will register, defaults to 5555
-    targetPort: # k8s service targetPort Arkouda will register, defaults to 5555
 ```
 
 #### metricsExporter

--- a/arkouda-helm-charts/arkouda-udp-server/templates/deployment.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/templates/deployment.yaml
@@ -21,9 +21,9 @@ spec:
             - name: ARKOUDA_SERVER_NAME
               value: {{ .Values.metricsExporter.service.name | quote}}
             - name: ARKOUDA_METRICS_SERVICE_HOST
-              value: {{ .Values.server.metrics.service.name | quote}}
+              value: {{ .Values.server.metrics.service.name | default "arkouda-metrics" | quote}}
             - name: ARKOUDA_METRICS_SERVICE_PORT
-              value: {{ .Values.server.metrics.service.port | quote}}
+              value: {{ .Values.server.metrics.service.port | default 5556 | quote}}
         {{- end }}
         - name: arkouda-server
           image: {{ .Values.imageRepository }}/arkouda-udp-server:{{ .Values.releaseVersion }}
@@ -40,10 +40,8 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           ports:
-          - containerPort: {{ .Values.server.service.port }}
-            hostPort: 5555
+          - containerPort: {{ .Values.server.service.port | default 5555 }}
           - containerPort: 22
-            hostPort: 25
           volumeMounts:
           - name: ssl
             mountPath: "/etc/ssl/arkouda"
@@ -82,9 +80,9 @@ spec:
             - name: GASNET_SUPERNODE_MAXSIZE
               value: '1' 
             - name: CERT_FILE
-              value: {{ .Values.external.certFile | quote }}
+              value: '/etc/ssl/arkouda/tls.crt'
             - name: KEY_FILE
-              value: {{ .Values.external.keyFile | quote }}
+              value: '/etc/ssl/arkouda/tls.key'
             - name: K8S_HOST
               value: {{ .Values.external.k8sHost | quote }} 
             - name: NAMESPACE
@@ -96,21 +94,21 @@ spec:
             - name: POD_METHOD
               value: {{ .Values.locale.podMethod | quote }}
             - name: EXTERNAL_SERVICE_NAME
-              value: {{ .Values.external.service.name | quote }}
+              value: {{ .Values.external.service.name | default "arkouda" | quote }}
             - name: EXTERNAL_SERVICE_PORT
-              value: {{ .Values.external.service.port | quote }}
+              value: {{ .Values.external.service.port | default 5555 | quote }}
             - name: EXTERNAL_SERVICE_TARGET_PORT
-              value: {{ .Values.external.service.targetPort | quote }}
+              value: {{ .Values.external.service.port | default 5555 |quote }}
             - name: LOG_LEVEL  
               value: {{ .Values.server.logLevel }}    
             - name: COLLECT_METRICS
               value: {{ .Values.server.metrics.collectMetrics | quote }}
             - name: METRICS_SERVICE_NAME
-              value: {{ .Values.server.metrics.service.name }}
+              value: {{ .Values.server.metrics.service.name | default "arkouda metrics" }}
             - name: METRICS_SERVICE_PORT
-              value: {{ .Values.server.metrics.service.port | quote }}
+              value: {{ .Values.server.metrics.service.port | default 5556 | quote }}
             - name: METRICS_SERVICE_TARGET_PORT
-              value: {{ .Values.server.metrics.service.targetPort | quote }}
+              value: {{ .Values.server.metrics.service.port | default 5556 | quote }}
       volumes:              
         - name: ssl
           secret:

--- a/arkouda-helm-charts/arkouda-udp-server/templates/deployment.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/templates/deployment.yaml
@@ -38,12 +38,7 @@ spec:
                 command: ['python3','-c', 'import os; service=os.environ["EXTERNAL_SERVICE_NAME"]; namespace=os.environ["NAMESPACE"]; from arkouda_integration.k8s import KubernetesDao; dao = KubernetesDao(cert_file=os.environ["CERT_FILE"],key_file=os.environ["KEY_FILE"],k8s_host=os.environ["K8S_HOST"]); dao.delete_service(service_name=service,namespace=namespace)']
               {{- end }}
           resources:
-            requests:
-              cpu: {{ .Values.resources.requests.cpu }}
-              memory: {{ .Values.resources.requests.memory }}
-            limits:
-              cpu: {{ .Values.resources.limits.cpu }}
-              memory: {{ .Values.resources.limits.memory }}
+            {{- toYaml .Values.resources | nindent 12 }}
           ports:
           - containerPort: {{ .Values.server.service.port }}
             hostPort: 5555

--- a/arkouda-helm-charts/arkouda-udp-server/values.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/values.yaml
@@ -1,4 +1,4 @@
-# Default values for arkouda-udp-server chart.
+# Default values for arkouda-driver-chart.
 
 resources:
   limits:
@@ -11,53 +11,55 @@ resources:
 ######################## Pod Settings ########################
 
 imageRepository: bearsrus
-releaseVersion: v2023.04.07
+releaseVersion: v2023.05.05
 imagePullPolicy: IfNotPresent
 
-################ Arkouda Server Configuration ################
+################ Arkouda Driver Configuration ################
 
 server: 
   numLocales: # total number of Arkouda locales = number of arkouda-udp-locale pods + 1
-  authenticate: # whether to require token authentication
-  verbose: # enable verbose logging
-  memTrack: true
+  authenticate: false # whether to require token authentication
+  verbose: true # enable verbose logging
   threadsPerLocale: # number of cpu cores to be used per locale
   memMax: # maximum bytes of RAM to be used per locale
-  logLevel: LogLevel.INFO
+  memTrack: true
+  logLevel: LogLevel.DEBUG
   service:
-    type: # k8s service type, usually ClusterIP, NodePort, or LoadBalancer
+    type: ClusterIP # k8s service type, usually ClusterIP, NodePort, or LoadBalancer
     port: # service port Arkouda is listening on, defaults to 5555
+    targetPort: 5555 # if service type is ClusterIP or LoadBalancer, defaults to 5555
     nodeport: # if service type is Nodeport
-    name: # service name
+    name: arkouda # service name
   metrics:
-    collectMetrics: # whether to collect metrics and make them available via  k8s service
+    collectMetrics: false # whether to collect metrics and make them available via  k8s service
     service:
-      name: # k8s service name for the Arkouda metrics service endpoint
+      name: arkouda-metrics # k8s service name for the Arkouda metrics service endpoint
       port: # k8s service port for the Arkouda metrics service endpoint, defaults to 5556
+      targetPort: 5556 # k8s targetPort mapping to the Arkouda metrics port, defaults to 5556
 locale:
   appName: arkouda-locale
   podMethod: GET_POD_IPS
 external:
   persistence:
     enabled: false
-    path: /opt/locale # pod directory path DO NOT CHANGE
-    hostPath: # host machine path
+    path: /arkouda-files # pod directory path, must match arkouda-udp-locale
+    hostPath: # host machine path, must match arkouda-udp-locale
   certFile: /etc/ssl/arkouda/tls.crt
   keyFile: /etc/ssl/arkouda/tls.key
-  k8sHost: # Kubernetes API url (result of kubectl cluster-info command) 
-  namespace: # namespace Arkouda will register service
+  k8sHost:
+  namespace: arkouda # namespace Arkouda will register service
   service: 
-    name: # k8s service name Arkouda will register
-    port: # k8s service port Arkouda will register, defaults to 5555
+    name: arkouda # k8s service name Arkouda will register
+    port: 5555 # k8s service port Arkouda will register, defaults to 5555
+    targetPort: 5555 # k8s service targetPort Arkouda will register, defaults to 5555
 metricsExporter:
   imageRepository: bearsrus
-  releaseVersion: # prometheus-arkouda-exporter release version
+  releaseVersion: v2023.05.05 # prometheus-arkouda-exporter release version
   imagePullPolicy: IfNotPresent
   service:
     name: # prometheus-arkouda-exporter service name
-    port: # prometheus-arkouda-exporter service port, defaults to 5080
+    port: 5080 # prometheus-arkouda-exporter service port, defaults to 5080
   pollingIntervalSeconds: 5
 secrets:
   tls: # name of tls secret used to access Kubernetes API
   ssh: # name of ssh secret used to launch Arkouda locales
-

--- a/arkouda-helm-charts/arkouda-udp-server/values.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/values.yaml
@@ -1,4 +1,4 @@
-# Default values for arkouda-driver-chart.
+# Default values for udp-arkouda-server chart
 
 resources:
   limits:
@@ -26,16 +26,15 @@ server:
   logLevel: LogLevel.DEBUG
   service:
     type: ClusterIP # k8s service type, usually ClusterIP, NodePort, or LoadBalancer
-    port: # service port Arkouda is listening on, defaults to 5555
-    targetPort: 5555 # if service type is ClusterIP or LoadBalancer, defaults to 5555
+    port: # k8s service port Arkouda is listening on, defaults to 5555
     nodeport: # if service type is Nodeport
-    name: arkouda # service name
+    name: # k8s service name
   metrics:
     collectMetrics: false # whether to collect metrics and make them available via  k8s service
     service:
-      name: arkouda-metrics # k8s service name for the Arkouda metrics service endpoint
+      name: # k8s service name for the Arkouda metrics service endpoint
       port: # k8s service port for the Arkouda metrics service endpoint, defaults to 5556
-      targetPort: 5556 # k8s targetPort mapping to the Arkouda metrics port, defaults to 5556
+      targetPort: # k8s targetPort mapping to the Arkouda metrics port, defaults to 5556
 locale:
   appName: arkouda-locale
   podMethod: GET_POD_IPS
@@ -44,14 +43,11 @@ external:
     enabled: false
     path: /arkouda-files # pod directory path, must match arkouda-udp-locale
     hostPath: # host machine path, must match arkouda-udp-locale
-  certFile: /etc/ssl/arkouda/tls.crt
-  keyFile: /etc/ssl/arkouda/tls.key
   k8sHost:
-  namespace: arkouda # namespace Arkouda will register service
+  namespace: # namespace Arkouda will register service
   service: 
-    name: arkouda # k8s service name Arkouda will register
-    port: 5555 # k8s service port Arkouda will register, defaults to 5555
-    targetPort: 5555 # k8s service targetPort Arkouda will register, defaults to 5555
+    name: # k8s service name Arkouda will register
+    port: # k8s service port Arkouda will register, defaults to 5555
 metricsExporter:
   imageRepository: bearsrus
   releaseVersion: v2023.05.05 # prometheus-arkouda-exporter release version


### PR DESCRIPTION
Closes #95 

This PR does the following:

1. upgrades arkouda-docker and arkouda-helm-charts to Arkouda v2023.05.05
2. fixes entrypoint error in arkouda-docker README.md
3. cleans up arkouda-helm-charts