### PR TITLE
create arkouda developer docker image

### DIFF
--- a/arkouda-docker/README.md
+++ b/arkouda-docker/README.md
@@ -14,9 +14,9 @@ and ipython interface to Arkouda. The arkouda-full-stack image extends bearsrus/
 ```
 # set env variables
 export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.30.0
-export ARKOUDA_BRANCH_NAME=2023.05.05
-export ARKOUDA_DISTRO_NAME=v2023.05.05
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.05.05.zip
+export ARKOUDA_BRANCH_NAME=2023.06.16
+export ARKOUDA_DISTRO_NAME=v2023.06.16
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.06.16.zip
 export ARKOUDA_IMAGE_REPO=bearsrus
 
 docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
@@ -35,7 +35,7 @@ By default arkouda-full-stack launches a jupyter notebook that is accessible via
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2023.05.05
+export ARKOUDA_VERSION=v2023.06.16
 
 docker run -it --rm -p 8888:8888 $ARKOUDA_IMAGE_REPO/arkouda-full-stack:$ARKOUDA_VERSION
 ```
@@ -47,7 +47,7 @@ To mount a directory containing files to be analyzed, execute the following comm
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2023.05.05
+export ARKOUDA_VERSION=v2023.06.16
 export HOST_DIR=/opt/datafiles
 export CONTAINER_DIR=/app/data
 
@@ -63,7 +63,7 @@ command is as follows:
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2023.05.05
+export ARKOUDA_VERSION=v2023.06.16
 
 docker run -it --rm -p 8888:8888 --entrypoint=/opt/arkouda/start-smp-arkouda-full-stack.sh \
                     $ARKOUDA_IMAGE_REPO/arkouda-full-stack:$ARKOUDA_VERSION
@@ -80,9 +80,9 @@ The arkouda-smp-server extends bearsrus/chapel-gasnet-smp to deliver a GASNET sm
 
 ```
 export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.30.0
-export ARKOUDA_DISTRO_NAME=v2023.05.05
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.05.05.zip
-export ARKOUDA_BRANCH_NAME=2023.05.05
+export ARKOUDA_DISTRO_NAME=v2023.06.16
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.06.16.zip
+export ARKOUDA_BRANCH_NAME=2023.06.16
 export ARKOUDA_IMAGE_REPO=bearsrus
 
 docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
@@ -97,7 +97,7 @@ docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2023.05.05
+export ARKOUDA_VERSION=v2023.06.16
 
 docker run -it --rm -p 5555:5555 $ARKOUDA_IMAGE_REPO/arkouda-smp-server:$ARKOUDA_VERSION
 ```
@@ -133,9 +133,9 @@ The arkouda-udp-server image extends bearsrus/chapel-gasnet-udp to deliver a GAS
 
 ```
 export CHAPEL_UDP_IMAGE=bearsrus/chapel-gasnet-udp:1.30.0
-export ARKOUDA_DISTRO_NAME=v2023.05.05
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.05.05.zip
-export ARKOUDA_BRANCH_NAME=2023.05.05
+export ARKOUDA_DISTRO_NAME=v2023.06.16
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.06.16.zip
+export ARKOUDA_BRANCH_NAME=2023.06.16
 export ARKOUDA_INTEGRATION_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda-contrib/archive/refs/heads/main.zip
 export ARKOUDA_INTEGRATION_DISTRO_NAME=main
 export ARKOUDA_IMAGE_REPO=bearsrus
@@ -173,10 +173,10 @@ There are six build arguments passed in to the docker build command:
 An example docker build command sequence is as follows:
 
 ```
-export EXPORTER_VERSION=v2023.05.05
-export ARKOUDA_DISTRO_NAME=v2023.05.05
-export ARKOUDA_BRANCH_NAME=2023.05.05
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.05.05.zip
+export EXPORTER_VERSION=v2023.06.16
+export ARKOUDA_DISTRO_NAME=v2023.06.16
+export ARKOUDA_BRANCH_NAME=2023.06.16
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.06.16.zip
 export ARKOUDA_CONTRIB_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda-contrib/archive/refs/heads/main.zip
 export ARKOUDA_CONTRIB_DISTRO_NAME=main
 
@@ -186,7 +186,7 @@ docker build --build-arg ARKOUDA_DISTRO_NAME=$ARKOUDA_DISTRO_NAME --build-arg AR
 ## Running prometheus-arkouda-exporter
 
 ```
-export EXPORTER_VERSION=v2023.05.05
+export EXPORTER_VERSION=v2023.06.16
 
 docker run -e ARKOUDA_METRICS_SERVICE_NAME=localhost -e ARKOUDA_METRICS_SERVICE_PORT=5556 -e POLLING_INTERVAL_SECONDS=5 -e EXPORT_PORT=5080 -e EXPORT_PORT=5080 -p 5080:5080 bearsrus/prometheus-arkouda-exporter:$EXPORTER_VERSION
 
@@ -230,7 +230,7 @@ Shown below are example build commands. To ensure the optimal, respective perfor
 ### arkouda-full-stack
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.05.05 --chapel_version=1.30.0 --image_type=arkouda-full-stack
+python build_docker_image.py --arkouda_tag=v2023.06.16 --chapel_version=1.30.0 --image_type=arkouda-full-stack
 ```
 
 ### chapel-gasnet-smp
@@ -242,7 +242,7 @@ python build_docker_image.py --chapel_version=1.30.0 --image_type=chapel-gasnet-
 ### arkouda-smp-server
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.05.05 --chapel_version=1.30.0 --image_type=arkouda-smp-server
+python build_docker_image.py --arkouda_tag=v2023.06.16 --chapel_version=1.30.0 --image_type=arkouda-smp-server
 ```
 
 ### chapel-gasnet-udp
@@ -254,12 +254,12 @@ python build_docker_image.py --chapel_version=1.30.0 --image_type=chapel-gasnet-
 ### arkouda-udp-server
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.05.05 --chapel_version=1.30.0 --image_type=arkouda-udp-server
+python build_docker_image.py --arkouda_tag=v2023.06.16 --chapel_version=1.30.0 --image_type=arkouda-udp-server
 ```
 
 ### prometheus-arkouda-exporter
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.05.05 --image_type=prometheus-arkouda-exporter
+python build_docker_image.py --arkouda_tag=v2023.06.16 --image_type=prometheus-arkouda-exporter
 ```
 

--- a/arkouda-docker/README.md
+++ b/arkouda-docker/README.md
@@ -190,6 +190,44 @@ export EXPORTER_VERSION=v2023.06.16
 
 docker run -e ARKOUDA_METRICS_SERVICE_NAME=localhost -e ARKOUDA_METRICS_SERVICE_PORT=5556 -e POLLING_INTERVAL_SECONDS=5 -e EXPORT_PORT=5080 -e EXPORT_PORT=5080 -p 5080:5080 bearsrus/prometheus-arkouda-exporter:$EXPORTER_VERSION
 
+# arkouda-smp-developer
+
+## Background
+
+The arkouda-smp-developer image enables Arkouda developers to mount whichever directories they are working in (arkouda for Python, src for Chapel) to the arkouda-smp-developer docker container and be able to develop, build, and test within a pre-built Chapel and Arkouda dependencies stack. Since the GASNET\_COMM\_SUBSTRATE is smp, the developer can execute multi-locale Arkouda testing with the arkouda-smp-developer containre. 
+
+## Building arkouda-smp-developer Image
+
+The arkouda-smp-developer Docker build sequence is very similar to the arkouda-smp-server build sequence, an example of which is shown below:
+
+```
+export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.30.0
+export ARKOUDA_BRANCH_NAME=2023.06.16
+export ARKOUDA_DISTRO_NAME=v2023.06.16
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.06.16.zip
+export ARKOUDA_IMAGE_REPO=bearsrus
+
+docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
+             --build-arg ARKOUDA_DISTRO_NAME=$ARKOUDA_DISTRO_NAME \
+             --build-arg ARKOUDA_DOWNLOAD_URL=$ARKOUDA_DOWNLOAD_URL \
+             --build-arg ARKOUDA_BRANCH_NAME=$ARKOUDA_BRANCH_NAME \
+             -f arkouda-smp-developer -t $ARKOUDA_IMAGE_REPO/arkouda-smp-developer:$ARKOUDA_DISTRO_NAME .
+```
+
+## Running arkouda-smp-developer
+
+Running arkouda-smp-developer with a directory mounted enables building, testing, and running Arkouda in GASNET smp mode within a Docker container. An example docker run command is shown below, where arkouda-smp-developer Docker container is launched from the Arkouda project root directory and the Chapel src directory is mounted:
+
+```
+# set env variables
+export ARKOUDA_IMAGE_REPO=bearsrus
+export ARKOUDA_VERSION=v2023.06.16
+
+docker run -it --rm -v $PWD/src:/opt/arkouda/src bearsrus/arkouda-smp-developer:v2023.06.16 
+```
+
+Once the arkouda-smp-developer Docker container is started, any changes to the files within the mounted directory are permanent and retained after the Docker container is stopped. In the above example, the developer writes Chapel code and tests within the arkouda-smp-developer Docker container. Once development is complete, the Docker container can be stopped and the updated Chapel files are ready for further development, commit and check-in to github, etc...
+
 # Building Images with Python script
 
 ## Background
@@ -263,3 +301,8 @@ python build_docker_image.py --arkouda_tag=v2023.06.16 --chapel_version=1.30.0 -
 python build_docker_image.py --arkouda_tag=v2023.06.16 --image_type=prometheus-arkouda-exporter
 ```
 
+### arkouda-smp-developer
+
+```
+python build_docker_image.py --arkouda_tag=v2023.06.16 --chapel_version=1.30.0 --image_type=arkouda-smp-developer
+```

--- a/arkouda-docker/arkouda-smp-developer
+++ b/arkouda-docker/arkouda-smp-developer
@@ -1,0 +1,47 @@
+ARG CHAPEL_SMP_IMAGE=${CHAPEL_SMP_IMAGE}
+
+FROM ${CHAPEL_SMP_IMAGE}
+
+# Set arkouda env variables
+ARG ARKOUDA_DOWNLOAD_URL=${ARKOUDA_DOWNLOAD_URL}
+ENV ARKOUDA_DOWNLOAD_URL=${ARKOUDA_DOWNLOAD_URL}
+ARG ARKOUDA_DISTRO_NAME=${ARKOUDA_DISTRO_NAME}
+ENV ARKOUDA_DISTRO_NAME=${ARKOUDA_DISTRO_NAME}
+ARG ARKOUDA_BRANCH_NAME=${ARKOUDA_BRANCH_NAME}
+ENV ARKOUDA_BRANCH_NAME=${ARKOUDA_BRANCH_NAME}
+
+WORKDIR /opt
+RUN sudo chmod 777 /opt
+
+# Install dependencies
+RUN sudo apt-get update && sudo apt upgrade -y && \
+    sudo apt-get install unzip libcurl4-openssl-dev -y
+
+# Download desired Arkouda distro, move to common /opt/arkouda dir
+RUN wget $ARKOUDA_DOWNLOAD_URL && \
+    unzip $ARKOUDA_DISTRO_NAME.zip && \
+    mv /opt/arkouda-$ARKOUDA_BRANCH_NAME /opt/arkouda 
+
+WORKDIR /opt/arkouda
+
+# Build and install deps
+RUN make install-deps
+
+# Build Arkouda
+RUN make
+
+# Remove unneeded files
+RUN sudo rm -rf /opt/$ARKOUDA_DISTRO_NAME.zip && \
+    cd /opt/arkouda && \
+    sudo rm -rf benchmarks converter examples *.md pictures runs test toys
+
+RUN mkdir object-files && \
+    mv src/*.o object-files/
+
+# Add startup script and set entrypoint
+ADD scripts/start-smp-arkouda-server.sh /opt/arkouda/start-smp-arkouda-server.sh
+ADD scripts/start-developer-container.sh /opt/arkouda/start-developer-container.sh
+
+EXPOSE 5555
+
+ENTRYPOINT sh /opt/arkouda/start-developer-container.sh

--- a/arkouda-docker/build_docker_image.py
+++ b/arkouda-docker/build_docker_image.py
@@ -12,6 +12,7 @@ class ImageType(Enum):
     CHAPEL_GASNET_UDP = 'chapel-gasnet-udp'
     CHAPEL_GASNET_SMP = 'chapel-gasnet-smp'
     PROMETHEUS_ARKOUDA_EXPORTER = 'prometheus-arkouda-exporter'
+    ARKOUDA_SMP_DEVELOPER = 'arkouda-smp-developer'
 
 def getImageFile(imageType: ImageType) -> str:
     '''
@@ -105,6 +106,16 @@ def buildImage(dockerRepo: str, chapelVersion: str, file: str, distro: str, tag:
                                                 '-t', f'{dockerTag}', '.'], stdout=subprocess.DEVNULL)
         print(result)
 
+    def buildArkoudaSmpDeveloper(dockerRepo: str, chapelVersion: str, file: str, dockerTag: str, distro: str, tag: Optional[str]) -> None:
+        result = subprocess.run(args=['docker','build',
+                                               '--build-arg', f'CHAPEL_SMP_IMAGE={generateChplSmpVersion(chapelVersion)}',
+                                               '--build-arg', f'ARKOUDA_DISTRO_NAME={getDistroName(distro=distro, tag=tag)}',
+                                               '--build-arg', f'ARKOUDA_DOWNLOAD_URL={generateArkoudaDownloadUrl(tag=tag,branch=distro)}',
+                                               '--build-arg', f'ARKOUDA_BRANCH_NAME={distro}',
+                                               '-f',file,
+                                               '-t', dockerTag, '.'], stdout=subprocess.DEVNULL)
+        print(result)
+
 
     dockerTag = generateBuildTag(dockerRepo=dockerRepo, file=file, tag=tag,distro=distro)
 
@@ -120,6 +131,8 @@ def buildImage(dockerRepo: str, chapelVersion: str, file: str, distro: str, tag:
         buildChapelSmp(dockerRepo=dockerRepo,chapelVersion=chapelVersion,file=file,dockerTag=dockerTag)
     elif file == ImageType.PROMETHEUS_ARKOUDA_EXPORTER.value:
         buildPrometheusArkoudaExporter(dockerRepo=dockerRepo,file=file,distro=distro,dockerTag=dockerTag,tag=tag)
+    elif file == ImageType.ARKOUDA_SMP_DEVELOPER.value:
+        buildArkoudaSmpDeveloper(dockerRepo=dockerRepo,chapelVersion=chapelVersion,file=file,dockerTag=dockerTag,distro=distro,tag=tag)
     else:
         raise ValueError(f'Dockerfile {file} is invalid, check command-line args')
 

--- a/arkouda-docker/scripts/start-developer-container.sh
+++ b/arkouda-docker/scripts/start-developer-container.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cp /opt/arkouda/object-files/*.o /opt/arkouda/src
+
+/bin/bash


### PR DESCRIPTION
This PR adds the following:

1. arkouda-smp-developer: Dockerfile for building the arkouda-smp-developer image
2. build_docker_image.py: update to build arkouda-smp-developer
3. README.md: update to detail how to build and run arkouda-smp-developer