### PR TITLE
upgrade arkouda helm charts to arkouda v2023.06.20

### DIFF
--- a/arkouda-helm-charts/arkouda-udp-locale/Chart.yaml
+++ b/arkouda-helm-charts/arkouda-udp-locale/Chart.yaml
@@ -6,4 +6,5 @@ type: application
 
 version: 1.1.0
 
-appVersion: v2023.05.05
+appVersion: v2023.06.20
+

--- a/arkouda-helm-charts/arkouda-udp-locale/values.yaml
+++ b/arkouda-helm-charts/arkouda-udp-locale/values.yaml
@@ -3,22 +3,22 @@
 ######################## Pod Settings ########################
 
 imageRepository: bearsrus
-releaseVersion: v2023.05.05
+releaseVersion: v2023.06.20
 imagePullPolicy: IfNotPresent
 
 resources:
   limits:
-    cpu: 1000m
-    memory: 1024Mi
+    cpu: 2000m
+    memory: 4096Mi
   requests:
-    cpu: 1000m
-    memory: 1024Mi
+    cpu: 2000m
+    memory: 2048Mi
 
 ################ Arkouda Locale Configuration ################
 
 server: 
   port: # Arkouda port, defaults to 5555
-  memTrack: true
+  memTrack: true # needs to be true to enable memory metrics and memory use forecasting 
   numLocales: # number of arkouda-udp-locale pods
   threadsPerLocale: # number of CPU cores for each locale
 external:

--- a/arkouda-helm-charts/arkouda-udp-server/Chart.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/Chart.yaml
@@ -6,5 +6,5 @@ type: application
 
 version: 1.1.0
 
-appVersion: v2023.05.05
+appVersion: v2023.06.20
 

--- a/arkouda-helm-charts/arkouda-udp-server/README.md
+++ b/arkouda-helm-charts/arkouda-udp-server/README.md
@@ -159,7 +159,7 @@ The arkouda-udp-server Helm deployment is configured within the [values.yaml](va
 
 ```
 server:
-  numLocales: # total number of Arkouda locales = number of arkouda-udp-locale pods + 1
+  totalNumLocales: # totalNumLocales = number of arkouda-udp-locale pods + 1 (arkouda-udp-server pod)
   authenticate: # whether to require token authentication
   verbose: # enable verbose logging
   memTrack: true

--- a/arkouda-helm-charts/arkouda-udp-server/values.yaml
+++ b/arkouda-helm-charts/arkouda-udp-server/values.yaml
@@ -1,28 +1,28 @@
-# Default values for udp-arkouda-server chart
+# Default values for arkouda-udp-server chart
 
 resources:
   limits:
-    cpu: 1000m
-    memory: 1024Mi
+    cpu: 2000m
+    memory: 4096Mi
   requests:
-    cpu: 1000m
-    memory: 1024Mi
+    cpu: 2000m
+    memory: 2048Mi
 
 ######################## Pod Settings ########################
 
 imageRepository: bearsrus
-releaseVersion: v2023.05.05
+releaseVersion: v2023.06.20
 imagePullPolicy: IfNotPresent
 
 ################ Arkouda Driver Configuration ################
 
 server: 
-  numLocales: # total number of Arkouda locales = number of arkouda-udp-locale pods + 1
+  totalNumLocales: # totalNumLocales = number of arkouda-udp-locale pods + 1 (arkouda-udp-server pod)
   authenticate: false # whether to require token authentication
   verbose: true # enable verbose logging
   threadsPerLocale: # number of cpu cores to be used per locale
   memMax: # maximum bytes of RAM to be used per locale
-  memTrack: true
+  memTrack: true # needs to be true to enable memory metrics and memory use forecasting
   logLevel: LogLevel.DEBUG
   service:
     type: ClusterIP # k8s service type, usually ClusterIP, NodePort, or LoadBalancer
@@ -43,14 +43,14 @@ external:
     enabled: false
     path: /arkouda-files # pod directory path, must match arkouda-udp-locale
     hostPath: # host machine path, must match arkouda-udp-locale
-  k8sHost:
+  k8sHost: # result of kubectl cluster-info command
   namespace: # namespace Arkouda will register service
   service: 
     name: # k8s service name Arkouda will register
     port: # k8s service port Arkouda will register, defaults to 5555
 metricsExporter:
   imageRepository: bearsrus
-  releaseVersion: v2023.05.05 # prometheus-arkouda-exporter release version
+  releaseVersion: v2023.06.20 # prometheus-arkouda-exporter release version
   imagePullPolicy: IfNotPresent
   service:
     name: # prometheus-arkouda-exporter service name

--- a/arkouda-helm-charts/prometheus-arkouda-exporter/Chart.yaml
+++ b/arkouda-helm-charts/prometheus-arkouda-exporter/Chart.yaml
@@ -2,23 +2,8 @@ apiVersion: v2
 name: prometheus-arkouda-exporter
 description: The prometheus-arkouda-exporter Helm chart
 
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "v2023.04.07"
+appVersion: v2023.06.20

--- a/arkouda-helm-charts/prometheus-arkouda-exporter/values.yaml
+++ b/arkouda-helm-charts/prometheus-arkouda-exporter/values.yaml
@@ -16,7 +16,7 @@ resources: {}
 
 ########################## Pod Settings ###########################
 
-releaseVersion: # prometheus-arkouda-exporter release version
+releaseVersion: v2023.06.20 # prometheus-arkouda-exporter release version
 imagePullPolicy: IfNotPresent
 
 ############ prometheus-arkouda-exporter Configuration ############


### PR DESCRIPTION
Closes #108 

This PR does the following:

1. upgrades all charts to Arkouda v2023.06.20
2. renames values.yaml param to clarify num locales
3. updates doc comments in values.yaml files and README.md