### PR TITLE
upgrade bearsrus images to Arkouda v2023.11.15

### DIFF
--- a/arkouda-docker/README.md
+++ b/arkouda-docker/README.md
@@ -13,10 +13,10 @@ and ipython interface to Arkouda. The arkouda-full-stack image extends bearsrus/
 
 ```
 # set env variables
-export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.31.0
-export ARKOUDA_BRANCH_NAME=2023.09.06
-export ARKOUDA_DISTRO_NAME=v2023.09.06
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.09.06.zip
+export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.32.0
+export ARKOUDA_BRANCH_NAME=2023.11.15
+export ARKOUDA_DISTRO_NAME=v2023.11.15
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.11.15.zip
 export ARKOUDA_IMAGE_REPO=bearsrus
 
 docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
@@ -28,14 +28,14 @@ docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
 
 ## Running arkouda-full-stack
 
-By default arkouda-full-stack launches a jupyter notebook that is accessible via http://$HOSTNAME:8888
+By default arkouda-full-stack launches a jupyter notebook that is accessible via http://$HOSTNAME:8888/lab
 
 ### Basic Configuration
 
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2023.09.06
+export ARKOUDA_VERSION=v2023.11.15
 
 docker run -it --rm -p 8888:8888 $ARKOUDA_IMAGE_REPO/arkouda-full-stack:$ARKOUDA_VERSION
 ```
@@ -47,7 +47,7 @@ To mount a directory containing files to be analyzed, execute the following comm
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2023.09.06
+export ARKOUDA_VERSION=v2023.11.15
 export HOST_DIR=/opt/datafiles
 export CONTAINER_DIR=/app/data
 
@@ -63,7 +63,7 @@ command is as follows:
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2023.09.06
+export ARKOUDA_VERSION=v2023.11.15
 
 docker run -it --rm -p 8888:8888 --entrypoint=/opt/arkouda/start-smp-arkouda-full-stack.sh \
                     $ARKOUDA_IMAGE_REPO/arkouda-full-stack:$ARKOUDA_VERSION
@@ -79,10 +79,10 @@ The arkouda-smp-server extends bearsrus/chapel-gasnet-smp to deliver a GASNET sm
 ## Building arkouda-smp-server
 
 ```
-export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.31.0
-export ARKOUDA_DISTRO_NAME=v2023.09.06
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.09.06.zip
-export ARKOUDA_BRANCH_NAME=2023.09.06
+export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.32.0
+export ARKOUDA_DISTRO_NAME=v2023.11.15
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.11.15.zip
+export ARKOUDA_BRANCH_NAME=2023.11.15
 export ARKOUDA_IMAGE_REPO=bearsrus
 
 docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
@@ -97,7 +97,7 @@ docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2023.09.06
+export ARKOUDA_VERSION=v2023.11.15
 
 docker run -it --rm -p 5555:5555 $ARKOUDA_IMAGE_REPO/arkouda-smp-server:$ARKOUDA_VERSION
 ```
@@ -117,7 +117,7 @@ across 1..n locales. Accordingly, the chapel-gasnet-udp image provides a base im
 
 ```
 export CHPL_BASE_IMAGE=ubuntu:22.04
-export CHPL_VERSION=1.31.0
+export CHPL_VERSION=1.32.0
 export CHAPEL_UDP_IMAGE_REPO=bearsrus
 
 docker build --build-arg CHPL_BASE_IMAGE=$CHPL_BASE_IMAGE \
@@ -134,10 +134,10 @@ The arkouda-udp-server image extends bearsrus/chapel-gasnet-udp to deliver a GAS
 ## Building arkouda-udp-server
 
 ```
-export CHAPEL_UDP_IMAGE=bearsrus/chapel-gasnet-udp:1.31.0
-export ARKOUDA_DISTRO_NAME=v2023.09.06
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.09.06.zip
-export ARKOUDA_BRANCH_NAME=2023.09.06
+export CHAPEL_UDP_IMAGE=bearsrus/chapel-gasnet-udp:1.32.0
+export ARKOUDA_DISTRO_NAME=v2023.11.15
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.11.15.zip
+export ARKOUDA_BRANCH_NAME=2023.11.15
 export ARKOUDA_INTEGRATION_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda-contrib/archive/refs/heads/main.zip
 export ARKOUDA_INTEGRATION_DISTRO_NAME=main
 export ARKOUDA_IMAGE_REPO=bearsrus
@@ -175,10 +175,10 @@ There are six build arguments passed in to the docker build command:
 An example docker build command sequence is as follows:
 
 ```
-export EXPORTER_VERSION=v2023.09.06
-export ARKOUDA_DISTRO_NAME=v2023.09.06
-export ARKOUDA_BRANCH_NAME=2023.09.06
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.09.06.zip
+export EXPORTER_VERSION=v2023.11.15
+export ARKOUDA_DISTRO_NAME=v2023.11.15
+export ARKOUDA_BRANCH_NAME=2023.11.15
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.11.15.zip
 export ARKOUDA_CONTRIB_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda-contrib/archive/refs/heads/main.zip
 export ARKOUDA_CONTRIB_DISTRO_NAME=main
 
@@ -193,7 +193,7 @@ docker build --build-arg ARKOUDA_DISTRO_NAME=$ARKOUDA_DISTRO_NAME \
 ## Running prometheus-arkouda-exporter
 
 ```
-export EXPORTER_VERSION=v2023.09.06
+export EXPORTER_VERSION=v2023.11.15
 
 docker run -e ARKOUDA_METRICS_SERVICE_NAME=localhost -e ARKOUDA_METRICS_SERVICE_PORT=5556 -e POLLING_INTERVAL_SECONDS=5 -e EXPORT_PORT=5080 -e EXPORT_PORT=5080 -p 5080:5080 bearsrus/prometheus-arkouda-exporter:$EXPORTER_VERSION
 ```
@@ -209,10 +209,10 @@ The arkouda-smp-developer image enables Arkouda developers to mount whichever di
 The arkouda-smp-developer Docker build sequence is very similar to the arkouda-smp-server build sequence, an example of which is shown below:
 
 ```
-export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.31.0
-export ARKOUDA_BRANCH_NAME=2023.09.06
-export ARKOUDA_DISTRO_NAME=v2023.09.06
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.09.06.zip
+export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.32.0
+export ARKOUDA_BRANCH_NAME=2023.11.15
+export ARKOUDA_DISTRO_NAME=v2023.11.15
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.11.15.zip
 export ARKOUDA_IMAGE_REPO=bearsrus
 
 docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
@@ -224,14 +224,14 @@ docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
 
 ## Running arkouda-smp-developer
 
-Running arkouda-smp-developer with a directory mounted enables building, testing, and running Arkouda in GASNET smp mode within a Docker container. An example docker run command is shown below, where arkouda-smp-developer Docker container is launched from the Arkouda project root directory and the src/ directory containing Arkouda .chpl files is mounted:
+Running arkouda-smp-developer with a directory mounted enables building, testing, and running Arkouda in GASNET smp mode within a Docker container. An example docker run command is shown below, where arkouda-smp-developer Docker container is launched from the Arkouda project root directory and the Chapel src directory is mounted:
 
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2023.09.06
+export ARKOUDA_VERSION=v2023.11.15
 
-docker run -it --rm -v $PWD/src:/opt/arkouda/src bearsrus/arkouda-smp-developer:v2023.09.06 
+docker run -it --rm -v $PWD/src:/opt/arkouda/src bearsrus/arkouda-smp-developer:v2023.11.15 
 ```
 
 Once the arkouda-smp-developer Docker container is started, any changes to the files within the mounted directory are permanent and retained 
@@ -246,7 +246,7 @@ Occasionally there are 1..n breaking changes introduced into Arkouda post-releas
 An example arkouda-smp-developer master branch build is as follows:
 
 ```
-export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.31.0
+export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.32.0
 export ARKOUDA_BRANCH_NAME=master
 export ARKOUDA_DISTRO_NAME=master
 export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/heads/master.zip
@@ -299,41 +299,41 @@ Shown below are example build commands. To ensure the optimal, respective perfor
 ### arkouda-full-stack
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.09.06 --chapel_version=1.31.0 --image_type=arkouda-full-stack
+python build_docker_image.py --arkouda_tag=v2023.11.15 --chapel_version=1.32.0 --image_type=arkouda-full-stack
 ```
 
 ### chapel-gasnet-smp
 
 ```
-python build_docker_image.py --chapel_version=1.31.0 --image_type=chapel-gasnet-smp
+python build_docker_image.py --chapel_version=1.32.0 --image_type=chapel-gasnet-smp
 ```
 
 ### arkouda-smp-server
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.09.06 --chapel_version=1.31.0 --image_type=arkouda-smp-server
+python build_docker_image.py --arkouda_tag=v2023.11.15 --chapel_version=1.32.0 --image_type=arkouda-smp-server
 ```
 
 ### chapel-gasnet-udp
 
 ```
-python build_docker_image.py --chapel_version=1.31.0 --image_type=chapel-gasnet-udp
+python build_docker_image.py --chapel_version=1.32.0 --image_type=chapel-gasnet-udp
 ```
 
 ### arkouda-udp-server
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.09.06 --chapel_version=1.31.0 --image_type=arkouda-udp-server
+python build_docker_image.py --arkouda_tag=v2023.11.15 --chapel_version=1.32.0 --image_type=arkouda-udp-server
 ```
 
 ### prometheus-arkouda-exporter
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.09.06 --image_type=prometheus-arkouda-exporter
+python build_docker_image.py --arkouda_tag=v2023.11.15 --image_type=prometheus-arkouda-exporter
 ```
 
 ### arkouda-smp-developer
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.09.06 --chapel_version=1.31.0 --image_type=arkouda-smp-developer
+python build_docker_image.py --arkouda_tag=v2023.11.15 --chapel_version=1.32.0 --image_type=arkouda-smp-developer
 ```


### PR DESCRIPTION
Closes #126 

This PR does the following:

1. Upgrades all bearsrus images to Arkouda v2023.11.15
2. Upgrades arkouda-udp-server image to Arkouda v2023.11.15 to Chapel 1.32.0 per [this bug fix](https://github.com/Bears-R-Us/arkouda/commit/f3596447d0868f17a5e3e0e2fdfcaed8c02310a6)