### PR TITLE
develop arkouda deploy and delete cron workflows

### DIFF
--- a/arkouda_workflows/README.md
+++ b/arkouda_workflows/README.md
@@ -15,6 +15,8 @@ There are four Arkouda argo workflows:
 
 The first two workflows are for deploying/deleting AoK while the latter two are for deploying prometheus-arkouda-exporter that exports Arkouda metrics for non-AoK deployments such as Arkouda-on-Slurm.
 
+In addition to Argo Workflows, there are two Arkouda [Argo Cron Workflows](https://argoproj.github.io/argo-workflows/cron-workflows/) that deploy and delete Arkouda at specific days and times via integration of Argo Workflows with [Unix/Linux crontab](https://www.techtarget.com/searchdatacenter/definition/crontab#:~:text=In%20Unix%20and%20Linux%2C%20cron,d%20scripts)
+
 ## Prerequisites
 
 ### Service Account and Role/Rolebinding
@@ -38,7 +40,7 @@ Information regarding the Arkouda SSH and TLS secrets is [here](https://github.c
 
 ### deploy arkouda workflow
 
-The [deploy-arkouda-on-kubernetes-command.sh](deploy-arkouda-on-kubernetes-command.sh) script is used to deploy AoK, utilizing several environment variables. An example is shown below:
+The [deploy-arkouda-on-kubernetes-command.sh](deploy-arkouda-on-kubernetes-command.sh) script is used to deploy AoK utilizing several environment variables. An example is shown below:
 
 ```
 export ARKOUDA_INSTANCE_NAME=arkouda-on-k8s
@@ -61,7 +63,7 @@ sh deploy-arkouda-on-kubernetes-command.sh
 
 ### delete arkouda workflow
 
-The [delete-arkouda-on-kubernetes-command.sh](delete-arkouda-on-kubernetes-command.sh) script is used to delete AoK, an example of which is shown below:
+The [delete-arkouda-on-kubernetes-command.sh](delete-arkouda-on-kubernetes-command.sh) script is used to delete AoK utilizing several environment variables. An example is shown below:
 
 ```
 export ARKOUDA_USER=arkouda
@@ -100,4 +102,63 @@ export ARKOUDA_EXPORTER_SERVICE_NAME=arkouda-on-slurm-exporter
 export ARKOUDA_EXPORTER_APP_NAME=arkouda-on-slurm-exporter
 
 sh delete-prometheus-arkouda-exporter-command.sh
+```
+
+## CronWorkflows
+
+The [deploy-arkouda-on-kubernetes-cronworkflow.sh](deploy-arkouda-on-kubernetes-cronworkflow.sh) script is used to deploy the deploy-arkouda-on-kubernetes CronWorkflow, which utilizes several environment variables to deploy AoK on a specific day and time. An example is shown below:
+
+```
+export ARKOUDA_INSTANCE_NAME=arkouda-on-k8s
+export ARKOUDA_NAMESPACE=arkouda
+export ARKOUDA_VERSION=v2023.11.15
+export ARKOUDA_SSH_SECRET=arkouda-ssh
+export ARKOUDA_SSL_SECRET=arkouda-tls
+export NUMBER_OF_LOCALES=2 # number of arkouda-locale instances
+export TOTAL_NUMBER_OF_LOCALES=3 # number of arkouda-locale instances + arkouda-server instance
+export KUBERNETES_URL=https://localhost:6443 # result of kubectl cluster-info
+export ARKOUDA_VERSION=v2023.11.15
+export ARKOUDA_CPU_CORES=2000m
+export ARKOUDA_MEMORY=2048Mi
+export CHPL_MEM_MAX=1000000000
+export CHPL_NUM_THREADS_PER_LOCALE=2
+export ARKOUDA_USER=arkouda
+
+sh deploy-arkouda-on-kubernetes-cronworkflow.sh
+```
+
+The default deploy-arkouda-on-kubernetes-cronworkflow configuration is to deploy arkouda-on-kubernetes daily at 0700 EST. The cron configuration can be changed in the spec.schedule section of the [deploy-arkouda-on-kubernetes-cronworkflow.yaml](deploy-arkouda-on-kubernetes-cronworkflow.yaml) file as shown below:
+
+```
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: deploy-arkouda-on-kubernetes
+spec:
+  schedule: "* 07 * * *"
+```
+
+### delete arkouda cron workflow
+
+The [delete-arkouda-on-kubernetes-cronworkflow.sh](delete-arkouda-on-kubernetes-cronworkflow.sh) script is used deploy the delete-arkouda-on-kubernetes CronWorkflow, which utilizes several environment variables to delete AoK on a specific day and time. An example is shown below:
+
+```
+export ARKOUDA_USER=arkouda
+export ARKOUDA_NAMESPACE=arkouda
+export ARKOUDA_INSTANCE_NAME=arkouda-on-k8s
+export ARKOUDA_SSL_SECRET=arkouda-tls
+export KUBERNETES_URL=https://localhost:6443 # result of kubectl cluster-info
+
+sh delete-arkouda-on-kubernetes-cronworkflow.sh
+```
+
+The default delete-arkouda-on-kubernetes-cronworkflow configuration is to delete arkouda-on-kubernetes daily at 1700 EST. The cron configuration can be changed in the spec.schedule section of the [delete-arkouda-on-kubernetes-cronworkflow.yaml](delete-arkouda-on-kubernetes-cronworkflow.yaml) file as shown below:
+
+```
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: delete-arkouda-on-kubernetes
+spec:
+  schedule: "* 17 * * *"
 ```

--- a/arkouda_workflows/README.md
+++ b/arkouda_workflows/README.md
@@ -127,7 +127,7 @@ export ARKOUDA_USER=arkouda
 sh deploy-arkouda-on-kubernetes-cronworkflow.sh
 ```
 
-The default deploy-arkouda-on-kubernetes-cronworkflow configuration is to deploy arkouda-on-kubernetes daily at 0700 EST. The cron configuration can be changed in the spec.schedule section of the [deploy-arkouda-on-kubernetes-cronworkflow.yaml](deploy-arkouda-on-kubernetes-cronworkflow.yaml) file as shown below:
+The default deploy-arkouda-on-kubernetes-cronworkflow configuration is to deploy arkouda-on-kubernetes daily at 0700 EST. The cron configuration can be changed in the [spec.schedule](https://github.com/hokiegeek2/arkouda-contrib/blob/62c099130d78ed523951aac11893298f3b9c752f/arkouda_workflows/deploy-arkouda-on-kubernetes-cronworkflow.yaml#L5) section of the deploy-arkouda-on-kubernetes-cronworkflow.yaml file as shown below:
 
 ```
 apiVersion: argoproj.io/v1alpha1
@@ -152,7 +152,7 @@ export KUBERNETES_URL=https://localhost:6443 # result of kubectl cluster-info
 sh delete-arkouda-on-kubernetes-cronworkflow.sh
 ```
 
-The default delete-arkouda-on-kubernetes-cronworkflow configuration is to delete arkouda-on-kubernetes daily at 1700 EST. The cron configuration can be changed in the spec.schedule section of the [delete-arkouda-on-kubernetes-cronworkflow.yaml](delete-arkouda-on-kubernetes-cronworkflow.yaml) file as shown below:
+The default delete-arkouda-on-kubernetes-cronworkflow configuration is to delete arkouda-on-kubernetes daily at 1700 EST. The cron configuration can be changed in the [spec.schedule](https://github.com/hokiegeek2/arkouda-contrib/blob/62c099130d78ed523951aac11893298f3b9c752f/arkouda_workflows/delete-arkouda-on-kubernetes-cronworkflow.yaml#L6) section of the delete-arkouda-on-kubernetes-cronworkflow.yaml file as shown below:
 
 ```
 apiVersion: argoproj.io/v1alpha1

--- a/arkouda_workflows/delete-arkouda-on-kubernetes-cronworkflow.sh
+++ b/arkouda_workflows/delete-arkouda-on-kubernetes-cronworkflow.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+argo cron create -n $ARKOUDA_NAMESPACE \
+                 delete-arkouda-on-kubernetes-cronworkflow.yaml \
+                 -p arkouda-ssl-secret=$ARKOUDA_SSL_SECRET \
+                 -p arkouda-instance-name=$ARKOUDA_INSTANCE_NAME \
+                 -p kubernetes-api-url=$KUBERNETES_URL \
+                 -p arkouda-user=$ARKOUDA_USER

--- a/arkouda_workflows/delete-arkouda-on-kubernetes-cronworkflow.yaml
+++ b/arkouda_workflows/delete-arkouda-on-kubernetes-cronworkflow.yaml
@@ -3,7 +3,7 @@ kind: CronWorkflow
 metadata:
   name: delete-arkouda-on-kubernetes
 spec:
-  schedule: "06 07 * * *"
+  schedule: "* 17 * * *"
   timezone: "America/New_York"   # Default to local machine timezone
   startingDeadlineSeconds: 0
   concurrencyPolicy: "Replace"      # Default to "Allow"

--- a/arkouda_workflows/delete-arkouda-on-kubernetes-cronworkflow.yaml
+++ b/arkouda_workflows/delete-arkouda-on-kubernetes-cronworkflow.yaml
@@ -1,0 +1,185 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: delete-arkouda-on-kubernetes
+spec:
+  schedule: "06 07 * * *"
+  timezone: "America/New_York"   # Default to local machine timezone
+  startingDeadlineSeconds: 0
+  concurrencyPolicy: "Replace"      # Default to "Allow"
+  successfulJobsHistoryLimit: 4     # Default 3
+  failedJobsHistoryLimit: 4         # Default 1
+  suspend: false                    # Set to "true" to suspend scheduling
+  workflowSpec:
+    entrypoint: delete-arkouda-on-kubernetes
+    serviceAccountName: arkouda-workflows-service-account
+    podGC:
+      strategy: OnWorkflowSuccess
+    arguments:
+      parameters:
+      - name: arkouda-instance-name
+      - name: kubernetes-api-url
+      - name: arkouda-ssl-secret
+      - name: arkouda-user   
+    templates:
+    - name: delete-arkouda-on-kubernetes
+      dag:
+        tasks:
+          - name: delete-arkouda-locale
+            template: delete-locale-deployment
+          - name: delete-locale-headless-service
+            template: delete-locale-headless-service
+          - name: delete-locale-ssh-service
+            template: delete-locale-ssh-service
+          - name: delete-arkouda-server
+            template: delete-server-deployment
+          - name: delete-server-headless-service
+            template: delete-server-headless-service
+          - name: delete-server-ssh-service
+            template: delete-server-ssh-service
+          - name: delete-arkouda-service
+            template: delete-arkouda-service
+          - name: delete-arkouda-metrics-service
+            template: delete-arkouda-metrics-service
+          - name: delete-arkouda-server-launch-script
+            template: delete-arkouda-server-launch-script
+          - name: delete-pod-role
+            template: delete-pod-role
+          - name: delete-pod-role-binding
+            template: delete-pod-role-binding
+          - name: delete-service-role
+            template: delete-service-role
+          - name: delete-service-role-binding
+            template: delete-service-role-binding
+          - name: delete-metrics-exporter-service
+            template: delete-metrics-exporter-service
+        
+    - name: delete-locale-deployment
+      resource:
+        action: delete
+        manifest: |
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-locale
+            labels:
+              app: {{ workflow.parameters.arkouda-instance-name }}-locale
+
+    - name: delete-locale-headless-service
+      resource:
+        action: delete
+        manifest: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-locale-headless
+
+    - name: delete-locale-ssh-service
+      resource:
+        action: delete
+        manifest: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-locale-ssh
+
+    - name: delete-server-deployment
+      resource:
+        action: delete
+        manifest: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-server
+            labels:
+              app: {{ workflow.parameters.arkouda-instance-name }}-server
+
+    - name: delete-server-headless-service
+      resource:
+        action: delete
+        manifest: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-server-headless
+
+    - name: delete-server-ssh-service
+      resource:
+        action: delete
+        manifest: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-server-ssh
+
+    - name: delete-arkouda-service
+      resource:
+        action: delete
+        manifest: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}
+
+    - name: delete-arkouda-metrics-service
+      resource:
+        action: delete
+        manifest: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-metrics
+
+    - name: delete-metrics-exporter-service
+      resource:
+        action: delete
+        manifest: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-metrics-exporter
+
+    - name: delete-arkouda-server-launch-script 
+      resource:
+        action: delete
+        manifest: |
+          kind: ConfigMap
+          apiVersion: v1
+          metadata:
+            name: arkouda-server-launch-script
+
+    - name: delete-pod-role
+      resource:
+        action: delete
+        manifest: |
+          kind: Role
+          apiVersion: rbac.authorization.k8s.io/v1
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-pod
+
+    - name: delete-pod-role-binding
+      resource:
+        action: delete
+        manifest: |
+          kind: RoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-pod-binding
+
+    - name: delete-service-role
+      resource:
+        action: delete
+        manifest: |
+          kind: Role
+          apiVersion: rbac.authorization.k8s.io/v1
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-service
+
+    - name: delete-service-role-binding
+      resource:
+        action: delete
+        manifest: |
+          kind: RoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-service-binding

--- a/arkouda_workflows/deploy-arkouda-on-kubernetes-cronworkflow.sh
+++ b/arkouda_workflows/deploy-arkouda-on-kubernetes-cronworkflow.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+argo cron create -n $ARKOUDA_NAMESPACE \
+            deploy-arkouda-on-kubernetes-cronworkflow.yaml \
+            -p arkouda-release-version=$ARKOUDA_VERSION \
+            -p arkouda-ssl-secret=$ARKOUDA_SSL_SECRET \
+            -p arkouda-ssh-secret=$ARKOUDA_SSH_SECRET \
+            -p arkouda-number-of-locales=$NUMBER_OF_LOCALES \
+            -p arkouda-instance-name=$ARKOUDA_INSTANCE_NAME \
+            -p arkouda-total-number-of-locales=$TOTAL_NUMBER_OF_LOCALES \
+            -p kubernetes-api-url=$KUBERNETES_URL \
+            -p arkouda-namespace=$ARKOUDA_NAMESPACE \
+            -p arkouda-log-level=LogLevel.DEBUG \
+            -p arkouda-user=$ARKOUDA_USER  \
+            -p metrics-polling-interval-seconds=15 \
+            -p image-pull-policy=IfNotPresent \
+            -p num-cpu-cores=$ARKOUDA_CPU_CORES \
+            -p memory=$ARKOUDA_MEMORY \
+            -p chpl-num-threads-per-locale=$CHPL_NUM_THREADS_PER_LOCALE \
+            -p chpl-mem-max=$CHPL_MEM_MAX

--- a/arkouda_workflows/deploy-arkouda-on-kubernetes-cronworkflow.yaml
+++ b/arkouda_workflows/deploy-arkouda-on-kubernetes-cronworkflow.yaml
@@ -3,7 +3,7 @@ kind: CronWorkflow
 metadata:
   name: deploy-arkouda-on-kubernetes
 spec:
-  schedule: "20 11 * * *"
+  schedule: "15 07 * * *"
   timezone: "America/New_York"   # Default to local machine timezone
   startingDeadlineSeconds: 0
   concurrencyPolicy: "Replace"      # Default to "Allow"
@@ -12,91 +12,275 @@ spec:
   suspend: false                    # Set to "true" to suspend scheduling
   workflowSpec:
     entrypoint: deploy-arkouda-on-kubernetes
-  podGC:
-    strategy: OnWorkflowSuccess
-  arguments:
-    parameters:
-    - name: arkouda-user
-    - name: arkouda-release-version
-    - name: arkouda-instance-name
-    - name: arkouda-ssl-secret
-    - name: arkouda-ssh-secret
-    - name: arkouda-number-of-locales
-    - name: arkouda-total-number-of-locales
-    - name: kubernetes-api-url
-    - name: arkouda-namespace
-    - name: arkouda-log-level
-    - name: image-pull-policy
-    - name: metrics-polling-interval-seconds
-    - name: num-cpu-cores
-    - name: memory    
-    - name: chpl-mem-max
-    - name: chpl-num-threads-per-locale
-    volumes:
-      - name: arkouda-files
-        persistentVolumeClaim:
-          claimName: arkouda-files
+    serviceAccountName: arkouda-workflows-service-account
+    podGC:
+      strategy: OnWorkflowSuccess
+    arguments:
+      parameters:
+      - name: arkouda-user
+      - name: arkouda-release-version
+      - name: arkouda-instance-name
+      - name: arkouda-ssl-secret
+      - name: arkouda-ssh-secret
+      - name: arkouda-number-of-locales
+      - name: arkouda-total-number-of-locales
+      - name: kubernetes-api-url
+      - name: arkouda-namespace
+      - name: arkouda-log-level
+      - name: image-pull-policy
+      - name: metrics-polling-interval-seconds
+      - name: num-cpu-cores
+      - name: memory    
+      - name: chpl-mem-max
+      - name: chpl-num-threads-per-locale
     templates:
-    - name: deploy-arkouda-on-kubernetes
-      dag:
-        tasks:
-          - name: deploy-arkouda-locale
-            template: deploy-locale
-          - name: create-locale-headless-service
-            template: create-locale-headless-service
-          - name: create-locale-ssh-service
-            template: create-locale-ssh-service
-          - name: create-pod-role
-            template: create-pod-role
-          - name: create-pod-role-binding
-            template: create-pod-role-binding
-            depends: 'create-pod-role.Succeeded'
-          - name: create-service-role
-            template: create-service-role
-          - name: create-service-role-binding
-            template: create-service-role-binding
-            depends: 'create-service-role.Succeeded'
-          - name: create-server-launch-script-config-map
-            template: create-server-launch-script-config-map
-            depends: 'deploy-arkouda-locale.Succeeded'
-          - name: create-server-headless-service
-            template: create-server-headless-service
-            depends: 'deploy-arkouda-locale.Succeeded'
-          - name: create-server-ssh-service
-            template: create-server-ssh-service
-            depends: 'deploy-arkouda-locale.Succeeded'
-          - name: deploy-arkouda-server
-            template: deploy-server
-            depends: 'deploy-arkouda-locale.Succeeded && create-server-launch-script-config-map.Succeeded'
-          - name: create-metrics-exporter-service
-            template: create-metrics-exporter-service
+      - name: deploy-arkouda-on-kubernetes
+        dag:
+          tasks:
+            - name: deploy-arkouda-locale
+              template: deploy-locale
+            - name: create-locale-headless-service
+              template: create-locale-headless-service
+            - name: create-locale-ssh-service
+              template: create-locale-ssh-service
+            - name: create-pod-role
+              template: create-pod-role
+            - name: create-pod-role-binding
+              template: create-pod-role-binding
+              depends: 'create-pod-role.Succeeded'
+            - name: create-service-role
+              template: create-service-role
+            - name: create-service-role-binding
+              template: create-service-role-binding
+              depends: 'create-service-role.Succeeded'
+            - name: create-server-launch-script-config-map
+              template: create-server-launch-script-config-map
+              depends: 'deploy-arkouda-locale.Succeeded'
+            - name: create-server-headless-service
+              template: create-server-headless-service
+              depends: 'deploy-arkouda-locale.Succeeded'
+            - name: create-server-ssh-service
+              template: create-server-ssh-service
+              depends: 'deploy-arkouda-locale.Succeeded'
+            - name: deploy-arkouda-server
+              template: deploy-server
+              depends: 'deploy-arkouda-locale.Succeeded && create-server-launch-script-config-map.Succeeded'
+            - name: create-metrics-exporter-service
+              template: create-metrics-exporter-service
             
-    - name: deploy-locale
-      resource:
-        action: create
-        manifest: |
-          apiVersion: apps/v1
-          kind: Deployment
-          metadata:
-            name: {{ workflow.parameters.arkouda-instance-name }}-locale
-            labels: 
-              app: {{ workflow.parameters.arkouda-instance-name }}-locale
-          spec:
-            replicas: {{ workflow.parameters.arkouda-number-of-locales }}
-            selector:
-              matchLabels:
+      - name: deploy-locale
+        resource:
+          action: create
+          manifest: |
+            apiVersion: apps/v1
+            kind: Deployment
+            metadata:
+              name: {{ workflow.parameters.arkouda-instance-name }}-locale
+              labels: 
                 app: {{ workflow.parameters.arkouda-instance-name }}-locale
-            template:
-              metadata:
-                labels:
+            spec:
+              replicas: {{ workflow.parameters.arkouda-number-of-locales }}
+              selector:
+                matchLabels:
                   app: {{ workflow.parameters.arkouda-instance-name }}-locale
-              spec:
+              template:
+                metadata:
+                  labels:
+                    app: {{ workflow.parameters.arkouda-instance-name }}-locale
+                spec:
+                  containers:
+                    - name: arkouda-udp-locale
+                      image: bearsrus/arkouda-udp-server:{{ workflow.parameters.arkouda-release-version }}
+                      imagePullPolicy: IfNotPresent
+                      command: [ "sh", "/opt/arkouda/start-arkouda-locale.sh" ]
+                      ports:
+                      - containerPort: 22
+                      resources:
+                        limits:
+                          cpu: {{ workflow.parameters.num-cpu-cores }}
+                          memory: {{ workflow.parameters.memory }}
+                        requests:
+                          cpu: {{ workflow.parameters.num-cpu-cores }}
+                          memory: {{ workflow.parameters.memory }}
+                      volumeMounts:
+                        - name: ssl
+                          mountPath: "/etc/ssl/arkouda"
+                        - name: ssh
+                          mountPath: "/home/ubuntu/ssh-keys"      
+                      env:
+                        - name: MY_IP
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: status.podIP
+                        - name: NUM_LOCALES
+                          value: '{{ workflow.parameters.arkouda-number-of-locales }}'
+                        - name: MEMTRACK
+                          value: 'true'
+                        - name: CHPL_RT_NUM_THREADS_PER_LOCALE
+                          value: '{{ workflow.parameters.chpl-num-threads-per-locale }}'
+                  volumes:
+                    - name: ssl
+                      secret:
+                        secretName: "{{ workflow.parameters.arkouda-ssl-secret }}"
+                    - name: ssh
+                      secret:
+                        secretName: "{{ workflow.parameters.arkouda-ssh-secret }}"
+
+      - name: create-locale-headless-service
+        resource:
+          action: create
+          manifest: |
+            apiVersion: v1
+            kind: Service
+            metadata:
+              name: {{ workflow.parameters.arkouda-instance-name }}-locale-headless
+            spec: 
+              clusterIP: None
+              selector:
+                app: {{ workflow.parameters.arkouda-instance-name }}-locale
+  
+      - name: create-locale-ssh-service
+        resource:
+          action: create
+          manifest: |
+            apiVersion: v1
+            kind: Service
+            metadata:
+              name: {{ workflow.parameters.arkouda-instance-name }}-locale-ssh
+            spec:
+              type: ClusterIP
+              ports:
+                - port: 22
+              selector:
+                app: {{ workflow.parameters.arkouda-instance-name }}-locale
+
+      - name: create-pod-role
+        resource: 
+          action: create
+          manifest: |
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: Role
+            metadata:
+              name: "{{ workflow.parameters.arkouda-instance-name }}-pod"
+            rules:
+              - apiGroups: [""]
+                resources: ["pods","deployments"]
+                verbs: ["get", "watch", "list"]
+ 
+      - name: create-pod-role-binding
+        resource:
+          action: create
+          manifest: |
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: RoleBinding
+            metadata:
+              name: "{{ workflow.parameters.arkouda-instance-name }}-pod-binding"
+            subjects:
+            - kind: User
+              name: "{{ workflow.parameters.arkouda-user }}"
+              apiGroup: rbac.authorization.k8s.io
+            roleRef:
+              kind: Role
+              name: "{{ workflow.parameters.arkouda-instance-name }}-pod"
+              apiGroup: rbac.authorization.k8s.io
+
+      - name: create-service-role
+        resource:
+          action: create
+          manifest: |
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: Role
+            metadata:
+              name: {{ workflow.parameters.arkouda-instance-name }}-service
+            rules:
+              - apiGroups: [""]
+                resources: ["services","endpoints"]
+                verbs: ["get","watch","list","create","delete","update"]
+
+      - name: create-service-role-binding
+        resource:
+          action: create 
+          manifest: |
+            kind: RoleBinding
+            apiVersion: rbac.authorization.k8s.io/v1
+            metadata:
+              name: {{ workflow.parameters.arkouda-instance-name }}-service-binding
+            subjects:
+            - kind: User
+              name: {{ workflow.parameters.arkouda-user }}
+              apiGroup: rbac.authorization.k8s.io
+            roleRef:
+              kind: Role
+              name: {{ workflow.parameters.arkouda-instance-name }}-service
+              apiGroup: rbac.authorization.k8s.io
+
+      - name: create-server-launch-script-config-map
+        resource:
+          action: create
+          manifest: |
+            kind: ConfigMap
+            apiVersion: v1
+            metadata:
+              name: arkouda-server-launch-script
+              labels:
+                name: arkouda-server-launch-script
+            data:
+              script: |-
+
+                  #!/bin/bash
+                  sudo service ssh start
+
+                  mkdir ~/.ssh/
+                  sudo cp ~/ssh-keys/id_rsa* ~/.ssh/
+                  sudo chown -R ubuntu:ubuntu ~/.ssh/*
+                  chmod -R 600 ~/.ssh/*
+
+                  cat ~/.ssh/id_rsa.pub > ~/.ssh/authorized_keys
+
+                  export LOCALE_IPS="$(python3 /opt/arkouda-contrib/arkouda_integration/client/scripts/pods.py '-c=$CERT_FILE' '-k=$KEY_FILE' '-kh=$K8S_HOST' '-i=GET_POD_IPS' '-n=arkouda' '-a={{ workflow.parameters.arkouda-instance-name }}-locale')"
+                  export SSH_SERVERS="$MY_IP $LOCALE_IPS"
+
+                  /opt/arkouda/arkouda_server -nl ${NUMLOCALES:-1} --ExternalIntegration.systemType=SystemType.KUBERNETES \
+                                              --ServerDaemon.daemonTypes=ServerDaemonType.INTEGRATION,ServerDaemonType.METRICS \
+                                              --memTrack=${MEMTRACK:-true} --authenticate=${AUTHENTICATE:-false} \
+                                              --logLevel=${LOG_LEVEL:-LogLevel.INFO}
+
+      - name: deploy-server
+        resource:
+          action: create
+          manifest: |
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: {{ workflow.parameters.arkouda-instance-name }}-server
+              labels:
+                app: {{ workflow.parameters.arkouda-instance-name }}-server
+            spec:
                 containers:
-                  - name: arkouda-udp-locale
-                    image: bearsrus/arkouda-udp-server:{{ workflow.parameters.arkouda-release-version }}
-                    imagePullPolicy: IfNotPresent
-                    command: [ "sh", "/opt/arkouda/start-arkouda-locale.sh" ]
+                  - name: arkouda-metrics-exporter
+                    image: bearsrus/prometheus-arkouda-exporter:{{ workflow.parameters.arkouda-release-version }}
+                    imagePullPolicy: {{ workflow.parameters.image-pull-policy }}
                     ports:
+                    - containerPort: 5080
+                    env:
+                      - name: EXPORT_PORT
+                        value: '5080'
+                      - name: POLLING_INTERVAL_SECONDS
+                        value: '{{ workflow.parameters.metrics-polling-interval-seconds }}'
+                      - name: ARKOUDA_SERVER_NAME
+                        value: '{{ workflow.parameters.arkouda-instance-name }}-metrics'
+                      - name: ARKOUDA_METRICS_SERVICE_HOST
+                        value: '{{ workflow.parameters.arkouda-instance-name }}-metrics'
+                      - name: ARKOUDA_METRICS_SERVICE_PORT
+                        value: '5556'
+
+                  - name: arkouda-udp-server
+                    image: bearsrus/arkouda-udp-server:{{ workflow.parameters.arkouda-release-version }}
+                    imagePullPolicy: {{ workflow.parameters.image-pull-policy }}
+                    command: [ "sh", "/opt/arkouda/start-arkouda-server.sh" ]
+                    ports:
+                    - containerPort: 5555
+                    - containerPort: 5556
                     - containerPort: 22
                     resources:
                       limits:
@@ -109,307 +293,120 @@ spec:
                       - name: ssl
                         mountPath: "/etc/ssl/arkouda"
                       - name: ssh
-                        mountPath: "/home/ubuntu/ssh-keys"      
+                        mountPath: "/home/ubuntu/ssh-keys"
+                      - name: arkouda-server-launch-script
+                        mountPath: /opt/arkouda/start-arkouda-server.sh
+                        subPath: start-arkouda-server.sh
                     env:
                       - name: MY_IP
                         valueFrom:
                           fieldRef:
                             fieldPath: status.podIP
-                      - name: NUM_LOCALES
-                        value: '{{ workflow.parameters.arkouda-number-of-locales }}'
+                      - name: GASNET_MASTERIP
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: status.podIP
+                      - name: SSH_SERVERS
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: status.podIP
+                      - name: NUMLOCALES
+                        value: '{{ workflow.parameters.arkouda-total-number-of-locales }}'
+                      - name: AUTHENTICATE
+                        value: 'false'
+                      - name: VERBOSE
+                        value: 'true'
                       - name: MEMTRACK
                         value: 'true'
                       - name: CHPL_RT_NUM_THREADS_PER_LOCALE
                         value: '{{ workflow.parameters.chpl-num-threads-per-locale }}'
-                volumes:
+                      - name: GASNET_SUPERNODE_MAXSIZE
+                        value: '1'
+                      - name: CERT_FILE
+                        value: '/etc/ssl/arkouda/tls.crt'
+                      - name: KEY_FILE
+                        value: '/etc/ssl/arkouda/tls.key'
+                      - name: K8S_HOST
+                        value: "{{ workflow.parameters.kubernetes-api-url }}"
+                      - name: NAMESPACE
+                        value: '{{ workflow.parameters.arkouda-namespace }}'
+                      - name: APP_NAME
+                        value: '{{ workflow.parameters.arkouda-instance-name }}-locale'
+                      - name: ARKOUDA_SERVER_NAME
+                        value: '{{ workflow.parameters.arkouda-instance-name }}'
+                      - name: ARKOUDA_CLIENT_MODE
+                        value: 'API'
+                      - name: POD_METHOD
+                        value: 'GET_POD_IPS'
+                      - name: EXTERNAL_SERVICE_NAME
+                        value: '{{ workflow.parameters.arkouda-instance-name }}'
+                      - name: EXTERNAL_SERVICE_PORT
+                        value: '5555'
+                      - name: EXTERNAL_SERVICE_TARGET_PORT
+                        value: '5555'
+                      - name: LOG_LEVEL
+                        value: '{{ workflow.parameters.arkouda-log-level }}'
+                      - name: COLLECT_METRICS
+                        value: 'true'
+                      - name: METRICS_SERVICE_NAME
+                        value: '{{ workflow.parameters.arkouda-instance-name }}-metrics'
+                      - name: METRICS_SERVICE_PORT
+                        value: '5556'
+                      - name: METRICS_SERVICE_TARGET_PORT
+                        value: '5556'
+                volumes:              
                   - name: ssl
                     secret:
                       secretName: "{{ workflow.parameters.arkouda-ssl-secret }}"
                   - name: ssh
                     secret:
                       secretName: "{{ workflow.parameters.arkouda-ssh-secret }}"
+                  - name: arkouda-server-launch-script
+                    configMap:
+                      name: arkouda-server-launch-script
+                      items:
+                        - key: script
+                          path: start-arkouda-server.sh
 
-    - name: create-locale-headless-service
-      resource:
-        action: create
-        manifest: |
-          apiVersion: v1
-          kind: Service
-          metadata:
-            name: {{ workflow.parameters.arkouda-instance-name }}-locale-headless
-          spec: 
-            clusterIP: None
-            selector:
-              app: {{ workflow.parameters.arkouda-instance-name }}-locale
-  
-    - name: create-locale-ssh-service
-      resource:
-        action: create
-        manifest: |
-          apiVersion: v1
-          kind: Service
-          metadata:
-            name: {{ workflow.parameters.arkouda-instance-name }}-locale-ssh
-          spec:
-            type: ClusterIP
-            ports:
-              - port: 22
-            selector:
-              app: {{ workflow.parameters.arkouda-instance-name }}-locale
+      - name: create-server-headless-service
+        resource:
+          action: create
+          manifest: |
+            apiVersion: v1
+            kind: Service
+            metadata:
+              name: {{ workflow.parameters.arkouda-instance-name }}-server-headless
+            spec:
+              clusterIP: None
+              selector:
+                app: {{ workflow.parameters.arkouda-instance-name }}-server
 
-    - name: create-pod-role
-      resource: 
-        action: create
-        manifest: |
-          apiVersion: rbac.authorization.k8s.io/v1
-          kind: Role
-          metadata:
-            name: "{{ workflow.parameters.arkouda-instance-name }}-pod"
-          rules:
-            - apiGroups: [""]
-              resources: ["pods","deployments"]
-              verbs: ["get", "watch", "list"]
+      - name: create-server-ssh-service
+        resource:
+          action: create
+          manifest: |
+            apiVersion: v1
+            kind: Service
+            metadata:
+              name: {{ workflow.parameters.arkouda-instance-name }}-server-ssh
+            spec:
+              type: ClusterIP
+              ports:
+                - port: 22
+              selector:
+                app: {{ workflow.parameters.arkouda-instance-name }}-server
 
-    - name: create-pod-role-binding
-      resource:
-        action: create
-        manifest: |
-          apiVersion: rbac.authorization.k8s.io/v1
-          kind: RoleBinding
-          metadata:
-            name: "{{ workflow.parameters.arkouda-instance-name }}-pod-binding"
-          subjects:
-          - kind: User
-            name: "{{ workflow.parameters.arkouda-user }}"
-            apiGroup: rbac.authorization.k8s.io
-          roleRef:
-            kind: Role
-            name: "{{ workflow.parameters.arkouda-instance-name }}-pod"
-            apiGroup: rbac.authorization.k8s.io
-
-    - name: create-service-role
-      resource:
-        action: create
-        manifest: |
-          apiVersion: rbac.authorization.k8s.io/v1
-          kind: Role
-          metadata:
-            name: {{ workflow.parameters.arkouda-instance-name }}-service
-          rules:
-            - apiGroups: [""]
-              resources: ["services","endpoints"]
-              verbs: ["get","watch","list","create","delete","update"]
-
-    - name: create-service-role-binding
-      resource:
-        action: create 
-        manifest: |
-          kind: RoleBinding
-          apiVersion: rbac.authorization.k8s.io/v1
-          metadata:
-            name: {{ workflow.parameters.arkouda-instance-name }}-service-binding
-          subjects:
-          - kind: User
-            name: {{ workflow.parameters.arkouda-user }}
-            apiGroup: rbac.authorization.k8s.io
-          roleRef:
-            kind: Role
-            name: {{ workflow.parameters.arkouda-instance-name }}-service
-            apiGroup: rbac.authorization.k8s.io
-
-    - name: create-server-launch-script-config-map
-      resource:
-        action: create
-        manifest: |
-          kind: ConfigMap
-          apiVersion: v1
-          metadata:
-            name: arkouda-server-launch-script
-            labels:
-              name: arkouda-server-launch-script
-          data:
-            script: |-
-  
-                #!/bin/bash
-                sudo service ssh start
-
-                mkdir ~/.ssh/
-                sudo cp ~/ssh-keys/id_rsa* ~/.ssh/
-                sudo chown -R ubuntu:ubuntu ~/.ssh/*
-                chmod -R 600 ~/.ssh/*
-
-                cat ~/.ssh/id_rsa.pub > ~/.ssh/authorized_keys
-
-                export LOCALE_IPS="$(python3 /opt/arkouda-contrib/arkouda_integration/client/scripts/pods.py '-c=$CERT_FILE' '-k=$KEY_FILE' '-kh=$K8S_HOST' '-i=GET_POD_IPS' '-n=arkouda' '-a={{ workflow.parameters.arkouda-instance-name }}-locale')"
-                export SSH_SERVERS="$MY_IP $LOCALE_IPS"
-
-                /opt/arkouda/arkouda_server -nl ${NUMLOCALES:-1} --ExternalIntegration.systemType=SystemType.KUBERNETES \
-                                            --ServerDaemon.daemonTypes=ServerDaemonType.INTEGRATION,ServerDaemonType.METRICS \
-                                            --memTrack=${MEMTRACK:-true} --authenticate=${AUTHENTICATE:-false} \
-                                            --logLevel=${LOG_LEVEL:-LogLevel.INFO}
-
-    - name: deploy-server
-      resource:
-        action: create
-        manifest: |
-          apiVersion: v1
-          kind: Pod
-          metadata:
-            name: {{ workflow.parameters.arkouda-instance-name }}-server
-            labels:
-              app: {{ workflow.parameters.arkouda-instance-name }}-server
-          spec:
-              containers:
-                - name: arkouda-metrics-exporter
-                  image: bearsrus/prometheus-arkouda-exporter:{{ workflow.parameters.arkouda-release-version }}
-                  imagePullPolicy: {{ workflow.parameters.image-pull-policy }}
-                  ports:
-                  - containerPort: 5080
-                  env:
-                    - name: EXPORT_PORT
-                      value: '5080'
-                    - name: POLLING_INTERVAL_SECONDS
-                      value: '{{ workflow.parameters.metrics-polling-interval-seconds }}'
-                    - name: ARKOUDA_SERVER_NAME
-                      value: '{{ workflow.parameters.arkouda-instance-name }}-metrics'
-                    - name: ARKOUDA_METRICS_SERVICE_HOST
-                      value: '{{ workflow.parameters.arkouda-instance-name }}-metrics'
-                    - name: ARKOUDA_METRICS_SERVICE_PORT
-                      value: '5556'
-
-                - name: arkouda-udp-server
-                  image: bearsrus/arkouda-udp-server:{{ workflow.parameters.arkouda-release-version }}
-                  imagePullPolicy: {{ workflow.parameters.image-pull-policy }}
-                  command: [ "sh", "/opt/arkouda/start-arkouda-server.sh" ]
-                  ports:
-                  - containerPort: 5555
-                  - containerPort: 5556
-                  - containerPort: 22
-                  resources:
-                    limits:
-                      cpu: {{ workflow.parameters.num-cpu-cores }}
-                      memory: {{ workflow.parameters.memory }}
-                    requests:
-                      cpu: {{ workflow.parameters.num-cpu-cores }}
-                      memory: {{ workflow.parameters.memory }}
-                  volumeMounts:
-                    - name: ssl
-                      mountPath: "/etc/ssl/arkouda"
-                    - name: ssh
-                      mountPath: "/home/ubuntu/ssh-keys"
-                    - name: arkouda-server-launch-script
-                      mountPath: /opt/arkouda/start-arkouda-server.sh
-                      subPath: start-arkouda-server.sh
-                  env:
-                    - name: MY_IP
-                      valueFrom:
-                        fieldRef:
-                          fieldPath: status.podIP
-                    - name: GASNET_MASTERIP
-                      valueFrom:
-                        fieldRef:
-                          fieldPath: status.podIP
-                    - name: SSH_SERVERS
-                      valueFrom:
-                        fieldRef:
-                          fieldPath: status.podIP
-                    - name: NUMLOCALES
-                      value: '{{ workflow.parameters.arkouda-total-number-of-locales }}'
-                    - name: AUTHENTICATE
-                      value: 'false'
-                    - name: VERBOSE
-                      value: 'true'
-                    - name: MEMTRACK
-                      value: 'true'
-                    - name: CHPL_RT_NUM_THREADS_PER_LOCALE
-                      value: '{{ workflow.parameters.chpl-num-threads-per-locale }}'
-                    - name: GASNET_SUPERNODE_MAXSIZE
-                      value: '1'
-                    - name: CERT_FILE
-                      value: '/etc/ssl/arkouda/tls.crt'
-                    - name: KEY_FILE
-                      value: '/etc/ssl/arkouda/tls.key'
-                    - name: K8S_HOST
-                      value: "{{ workflow.parameters.kubernetes-api-url }}"
-                    - name: NAMESPACE
-                      value: '{{ workflow.parameters.arkouda-namespace }}'
-                    - name: APP_NAME
-                      value: '{{ workflow.parameters.arkouda-instance-name }}-locale'
-                    - name: ARKOUDA_SERVER_NAME
-                      value: '{{ workflow.parameters.arkouda-instance-name }}'
-                    - name: ARKOUDA_CLIENT_MODE
-                      value: 'API'
-                    - name: POD_METHOD
-                      value: 'GET_POD_IPS'
-                    - name: EXTERNAL_SERVICE_NAME
-                      value: '{{ workflow.parameters.arkouda-instance-name }}'
-                    - name: EXTERNAL_SERVICE_PORT
-                      value: '5555'
-                    - name: EXTERNAL_SERVICE_TARGET_PORT
-                      value: '5555'
-                    - name: LOG_LEVEL
-                      value: '{{ workflow.parameters.arkouda-log-level }}'
-                    - name: COLLECT_METRICS
-                      value: 'true'
-                    - name: METRICS_SERVICE_NAME
-                      value: '{{ workflow.parameters.arkouda-instance-name }}-metrics'
-                    - name: METRICS_SERVICE_PORT
-                      value: '5556'
-                    - name: METRICS_SERVICE_TARGET_PORT
-                      value: '5556'
-              volumes:              
-                - name: ssl
-                  secret:
-                    secretName: "{{ workflow.parameters.arkouda-ssl-secret }}"
-                - name: ssh
-                  secret:
-                    secretName: "{{ workflow.parameters.arkouda-ssh-secret }}"
-                - name: arkouda-server-launch-script
-                  configMap:
-                    name: arkouda-server-launch-script
-                    items:
-                      - key: script
-                        path: start-arkouda-server.sh
-
-    - name: create-server-headless-service
-      resource:
-        action: create
-        manifest: |
-          apiVersion: v1
-          kind: Service
-          metadata:
-            name: {{ workflow.parameters.arkouda-instance-name }}-server-headless
-          spec:
-            clusterIP: None
-            selector:
-              app: {{ workflow.parameters.arkouda-instance-name }}-server
-
-    - name: create-server-ssh-service
-      resource:
-        action: create
-        manifest: |
-          apiVersion: v1
-          kind: Service
-          metadata:
-            name: {{ workflow.parameters.arkouda-instance-name }}-server-ssh
-          spec:
-            type: ClusterIP
-            ports:
-              - port: 22
-            selector:
-              app: {{ workflow.parameters.arkouda-instance-name }}-server
-
-    - name: create-metrics-exporter-service
-      resource: 
-        action: create
-        manifest: |
-          apiVersion: v1
-          kind: Service
-          metadata:
-            name: {{ workflow.parameters.arkouda-instance-name }}-metrics-exporter
-          spec: 
-            type: ClusterIP
-            ports:
-              - port: 5080
-            selector:
-              app: {{ workflow.parameters.arkouda-instance-name }}-server  
+      - name: create-metrics-exporter-service
+        resource: 
+          action: create
+          manifest: |
+            apiVersion: v1
+            kind: Service
+            metadata:
+              name: {{ workflow.parameters.arkouda-instance-name }}-metrics-exporter
+            spec: 
+              type: ClusterIP
+              ports:
+                - port: 5080
+              selector:
+                app: {{ workflow.parameters.arkouda-instance-name }}-server  

--- a/arkouda_workflows/deploy-arkouda-on-kubernetes-cronworkflow.yaml
+++ b/arkouda_workflows/deploy-arkouda-on-kubernetes-cronworkflow.yaml
@@ -1,0 +1,415 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: deploy-arkouda-on-kubernetes
+spec:
+  schedule: "20 11 * * *"
+  timezone: "America/New_York"   # Default to local machine timezone
+  startingDeadlineSeconds: 0
+  concurrencyPolicy: "Replace"      # Default to "Allow"
+  successfulJobsHistoryLimit: 4     # Default 3
+  failedJobsHistoryLimit: 4         # Default 1
+  suspend: false                    # Set to "true" to suspend scheduling
+  workflowSpec:
+    entrypoint: deploy-arkouda-on-kubernetes
+  podGC:
+    strategy: OnWorkflowSuccess
+  arguments:
+    parameters:
+    - name: arkouda-user
+    - name: arkouda-release-version
+    - name: arkouda-instance-name
+    - name: arkouda-ssl-secret
+    - name: arkouda-ssh-secret
+    - name: arkouda-number-of-locales
+    - name: arkouda-total-number-of-locales
+    - name: kubernetes-api-url
+    - name: arkouda-namespace
+    - name: arkouda-log-level
+    - name: image-pull-policy
+    - name: metrics-polling-interval-seconds
+    - name: num-cpu-cores
+    - name: memory    
+    - name: chpl-mem-max
+    - name: chpl-num-threads-per-locale
+    volumes:
+      - name: arkouda-files
+        persistentVolumeClaim:
+          claimName: arkouda-files
+    templates:
+    - name: deploy-arkouda-on-kubernetes
+      dag:
+        tasks:
+          - name: deploy-arkouda-locale
+            template: deploy-locale
+          - name: create-locale-headless-service
+            template: create-locale-headless-service
+          - name: create-locale-ssh-service
+            template: create-locale-ssh-service
+          - name: create-pod-role
+            template: create-pod-role
+          - name: create-pod-role-binding
+            template: create-pod-role-binding
+            depends: 'create-pod-role.Succeeded'
+          - name: create-service-role
+            template: create-service-role
+          - name: create-service-role-binding
+            template: create-service-role-binding
+            depends: 'create-service-role.Succeeded'
+          - name: create-server-launch-script-config-map
+            template: create-server-launch-script-config-map
+            depends: 'deploy-arkouda-locale.Succeeded'
+          - name: create-server-headless-service
+            template: create-server-headless-service
+            depends: 'deploy-arkouda-locale.Succeeded'
+          - name: create-server-ssh-service
+            template: create-server-ssh-service
+            depends: 'deploy-arkouda-locale.Succeeded'
+          - name: deploy-arkouda-server
+            template: deploy-server
+            depends: 'deploy-arkouda-locale.Succeeded && create-server-launch-script-config-map.Succeeded'
+          - name: create-metrics-exporter-service
+            template: create-metrics-exporter-service
+            
+    - name: deploy-locale
+      resource:
+        action: create
+        manifest: |
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-locale
+            labels: 
+              app: {{ workflow.parameters.arkouda-instance-name }}-locale
+          spec:
+            replicas: {{ workflow.parameters.arkouda-number-of-locales }}
+            selector:
+              matchLabels:
+                app: {{ workflow.parameters.arkouda-instance-name }}-locale
+            template:
+              metadata:
+                labels:
+                  app: {{ workflow.parameters.arkouda-instance-name }}-locale
+              spec:
+                containers:
+                  - name: arkouda-udp-locale
+                    image: bearsrus/arkouda-udp-server:{{ workflow.parameters.arkouda-release-version }}
+                    imagePullPolicy: IfNotPresent
+                    command: [ "sh", "/opt/arkouda/start-arkouda-locale.sh" ]
+                    ports:
+                    - containerPort: 22
+                    resources:
+                      limits:
+                        cpu: {{ workflow.parameters.num-cpu-cores }}
+                        memory: {{ workflow.parameters.memory }}
+                      requests:
+                        cpu: {{ workflow.parameters.num-cpu-cores }}
+                        memory: {{ workflow.parameters.memory }}
+                    volumeMounts:
+                      - name: ssl
+                        mountPath: "/etc/ssl/arkouda"
+                      - name: ssh
+                        mountPath: "/home/ubuntu/ssh-keys"      
+                    env:
+                      - name: MY_IP
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: status.podIP
+                      - name: NUM_LOCALES
+                        value: '{{ workflow.parameters.arkouda-number-of-locales }}'
+                      - name: MEMTRACK
+                        value: 'true'
+                      - name: CHPL_RT_NUM_THREADS_PER_LOCALE
+                        value: '{{ workflow.parameters.chpl-num-threads-per-locale }}'
+                volumes:
+                  - name: ssl
+                    secret:
+                      secretName: "{{ workflow.parameters.arkouda-ssl-secret }}"
+                  - name: ssh
+                    secret:
+                      secretName: "{{ workflow.parameters.arkouda-ssh-secret }}"
+
+    - name: create-locale-headless-service
+      resource:
+        action: create
+        manifest: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-locale-headless
+          spec: 
+            clusterIP: None
+            selector:
+              app: {{ workflow.parameters.arkouda-instance-name }}-locale
+  
+    - name: create-locale-ssh-service
+      resource:
+        action: create
+        manifest: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-locale-ssh
+          spec:
+            type: ClusterIP
+            ports:
+              - port: 22
+            selector:
+              app: {{ workflow.parameters.arkouda-instance-name }}-locale
+
+    - name: create-pod-role
+      resource: 
+        action: create
+        manifest: |
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            name: "{{ workflow.parameters.arkouda-instance-name }}-pod"
+          rules:
+            - apiGroups: [""]
+              resources: ["pods","deployments"]
+              verbs: ["get", "watch", "list"]
+
+    - name: create-pod-role-binding
+      resource:
+        action: create
+        manifest: |
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: "{{ workflow.parameters.arkouda-instance-name }}-pod-binding"
+          subjects:
+          - kind: User
+            name: "{{ workflow.parameters.arkouda-user }}"
+            apiGroup: rbac.authorization.k8s.io
+          roleRef:
+            kind: Role
+            name: "{{ workflow.parameters.arkouda-instance-name }}-pod"
+            apiGroup: rbac.authorization.k8s.io
+
+    - name: create-service-role
+      resource:
+        action: create
+        manifest: |
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-service
+          rules:
+            - apiGroups: [""]
+              resources: ["services","endpoints"]
+              verbs: ["get","watch","list","create","delete","update"]
+
+    - name: create-service-role-binding
+      resource:
+        action: create 
+        manifest: |
+          kind: RoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-service-binding
+          subjects:
+          - kind: User
+            name: {{ workflow.parameters.arkouda-user }}
+            apiGroup: rbac.authorization.k8s.io
+          roleRef:
+            kind: Role
+            name: {{ workflow.parameters.arkouda-instance-name }}-service
+            apiGroup: rbac.authorization.k8s.io
+
+    - name: create-server-launch-script-config-map
+      resource:
+        action: create
+        manifest: |
+          kind: ConfigMap
+          apiVersion: v1
+          metadata:
+            name: arkouda-server-launch-script
+            labels:
+              name: arkouda-server-launch-script
+          data:
+            script: |-
+  
+                #!/bin/bash
+                sudo service ssh start
+
+                mkdir ~/.ssh/
+                sudo cp ~/ssh-keys/id_rsa* ~/.ssh/
+                sudo chown -R ubuntu:ubuntu ~/.ssh/*
+                chmod -R 600 ~/.ssh/*
+
+                cat ~/.ssh/id_rsa.pub > ~/.ssh/authorized_keys
+
+                export LOCALE_IPS="$(python3 /opt/arkouda-contrib/arkouda_integration/client/scripts/pods.py '-c=$CERT_FILE' '-k=$KEY_FILE' '-kh=$K8S_HOST' '-i=GET_POD_IPS' '-n=arkouda' '-a={{ workflow.parameters.arkouda-instance-name }}-locale')"
+                export SSH_SERVERS="$MY_IP $LOCALE_IPS"
+
+                /opt/arkouda/arkouda_server -nl ${NUMLOCALES:-1} --ExternalIntegration.systemType=SystemType.KUBERNETES \
+                                            --ServerDaemon.daemonTypes=ServerDaemonType.INTEGRATION,ServerDaemonType.METRICS \
+                                            --memTrack=${MEMTRACK:-true} --authenticate=${AUTHENTICATE:-false} \
+                                            --logLevel=${LOG_LEVEL:-LogLevel.INFO}
+
+    - name: deploy-server
+      resource:
+        action: create
+        manifest: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-server
+            labels:
+              app: {{ workflow.parameters.arkouda-instance-name }}-server
+          spec:
+              containers:
+                - name: arkouda-metrics-exporter
+                  image: bearsrus/prometheus-arkouda-exporter:{{ workflow.parameters.arkouda-release-version }}
+                  imagePullPolicy: {{ workflow.parameters.image-pull-policy }}
+                  ports:
+                  - containerPort: 5080
+                  env:
+                    - name: EXPORT_PORT
+                      value: '5080'
+                    - name: POLLING_INTERVAL_SECONDS
+                      value: '{{ workflow.parameters.metrics-polling-interval-seconds }}'
+                    - name: ARKOUDA_SERVER_NAME
+                      value: '{{ workflow.parameters.arkouda-instance-name }}-metrics'
+                    - name: ARKOUDA_METRICS_SERVICE_HOST
+                      value: '{{ workflow.parameters.arkouda-instance-name }}-metrics'
+                    - name: ARKOUDA_METRICS_SERVICE_PORT
+                      value: '5556'
+
+                - name: arkouda-udp-server
+                  image: bearsrus/arkouda-udp-server:{{ workflow.parameters.arkouda-release-version }}
+                  imagePullPolicy: {{ workflow.parameters.image-pull-policy }}
+                  command: [ "sh", "/opt/arkouda/start-arkouda-server.sh" ]
+                  ports:
+                  - containerPort: 5555
+                  - containerPort: 5556
+                  - containerPort: 22
+                  resources:
+                    limits:
+                      cpu: {{ workflow.parameters.num-cpu-cores }}
+                      memory: {{ workflow.parameters.memory }}
+                    requests:
+                      cpu: {{ workflow.parameters.num-cpu-cores }}
+                      memory: {{ workflow.parameters.memory }}
+                  volumeMounts:
+                    - name: ssl
+                      mountPath: "/etc/ssl/arkouda"
+                    - name: ssh
+                      mountPath: "/home/ubuntu/ssh-keys"
+                    - name: arkouda-server-launch-script
+                      mountPath: /opt/arkouda/start-arkouda-server.sh
+                      subPath: start-arkouda-server.sh
+                  env:
+                    - name: MY_IP
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: status.podIP
+                    - name: GASNET_MASTERIP
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: status.podIP
+                    - name: SSH_SERVERS
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: status.podIP
+                    - name: NUMLOCALES
+                      value: '{{ workflow.parameters.arkouda-total-number-of-locales }}'
+                    - name: AUTHENTICATE
+                      value: 'false'
+                    - name: VERBOSE
+                      value: 'true'
+                    - name: MEMTRACK
+                      value: 'true'
+                    - name: CHPL_RT_NUM_THREADS_PER_LOCALE
+                      value: '{{ workflow.parameters.chpl-num-threads-per-locale }}'
+                    - name: GASNET_SUPERNODE_MAXSIZE
+                      value: '1'
+                    - name: CERT_FILE
+                      value: '/etc/ssl/arkouda/tls.crt'
+                    - name: KEY_FILE
+                      value: '/etc/ssl/arkouda/tls.key'
+                    - name: K8S_HOST
+                      value: "{{ workflow.parameters.kubernetes-api-url }}"
+                    - name: NAMESPACE
+                      value: '{{ workflow.parameters.arkouda-namespace }}'
+                    - name: APP_NAME
+                      value: '{{ workflow.parameters.arkouda-instance-name }}-locale'
+                    - name: ARKOUDA_SERVER_NAME
+                      value: '{{ workflow.parameters.arkouda-instance-name }}'
+                    - name: ARKOUDA_CLIENT_MODE
+                      value: 'API'
+                    - name: POD_METHOD
+                      value: 'GET_POD_IPS'
+                    - name: EXTERNAL_SERVICE_NAME
+                      value: '{{ workflow.parameters.arkouda-instance-name }}'
+                    - name: EXTERNAL_SERVICE_PORT
+                      value: '5555'
+                    - name: EXTERNAL_SERVICE_TARGET_PORT
+                      value: '5555'
+                    - name: LOG_LEVEL
+                      value: '{{ workflow.parameters.arkouda-log-level }}'
+                    - name: COLLECT_METRICS
+                      value: 'true'
+                    - name: METRICS_SERVICE_NAME
+                      value: '{{ workflow.parameters.arkouda-instance-name }}-metrics'
+                    - name: METRICS_SERVICE_PORT
+                      value: '5556'
+                    - name: METRICS_SERVICE_TARGET_PORT
+                      value: '5556'
+              volumes:              
+                - name: ssl
+                  secret:
+                    secretName: "{{ workflow.parameters.arkouda-ssl-secret }}"
+                - name: ssh
+                  secret:
+                    secretName: "{{ workflow.parameters.arkouda-ssh-secret }}"
+                - name: arkouda-server-launch-script
+                  configMap:
+                    name: arkouda-server-launch-script
+                    items:
+                      - key: script
+                        path: start-arkouda-server.sh
+
+    - name: create-server-headless-service
+      resource:
+        action: create
+        manifest: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-server-headless
+          spec:
+            clusterIP: None
+            selector:
+              app: {{ workflow.parameters.arkouda-instance-name }}-server
+
+    - name: create-server-ssh-service
+      resource:
+        action: create
+        manifest: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-server-ssh
+          spec:
+            type: ClusterIP
+            ports:
+              - port: 22
+            selector:
+              app: {{ workflow.parameters.arkouda-instance-name }}-server
+
+    - name: create-metrics-exporter-service
+      resource: 
+        action: create
+        manifest: |
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: {{ workflow.parameters.arkouda-instance-name }}-metrics-exporter
+          spec: 
+            type: ClusterIP
+            ports:
+              - port: 5080
+            selector:
+              app: {{ workflow.parameters.arkouda-instance-name }}-server  

--- a/arkouda_workflows/deploy-arkouda-on-kubernetes-cronworkflow.yaml
+++ b/arkouda_workflows/deploy-arkouda-on-kubernetes-cronworkflow.yaml
@@ -3,7 +3,7 @@ kind: CronWorkflow
 metadata:
   name: deploy-arkouda-on-kubernetes
 spec:
-  schedule: "15 07 * * *"
+  schedule: "* 07 * * *"
   timezone: "America/New_York"   # Default to local machine timezone
   startingDeadlineSeconds: 0
   concurrencyPolicy: "Replace"      # Default to "Allow"


### PR DESCRIPTION
Closes #132

This PR adds CronWorkflow variants of the deploy-arkouda-on-kubernetes and delete-arkouda-on-kubernetes Argo workflows, enabling each to be executed on a specific day at a specific time.