### PR TITLE
fix error in cronworkflow cron format

### DIFF
--- a/arkouda_workflows/delete-arkouda-on-kubernetes-cronworkflow.yaml
+++ b/arkouda_workflows/delete-arkouda-on-kubernetes-cronworkflow.yaml
@@ -3,7 +3,7 @@ kind: CronWorkflow
 metadata:
   name: delete-arkouda-on-kubernetes
 spec:
-  schedule: "* 17 * * *"
+  schedule: "0 18 * * *"
   timezone: "America/New_York"   # Default to local machine timezone
   startingDeadlineSeconds: 0
   concurrencyPolicy: "Replace"      # Default to "Allow"

--- a/arkouda_workflows/deploy-arkouda-on-kubernetes-cronworkflow.yaml
+++ b/arkouda_workflows/deploy-arkouda-on-kubernetes-cronworkflow.yaml
@@ -3,7 +3,7 @@ kind: CronWorkflow
 metadata:
   name: deploy-arkouda-on-kubernetes
 spec:
-  schedule: "* 07 * * *"
+  schedule: "0 07 * * *"
   timezone: "America/New_York"   # Default to local machine timezone
   startingDeadlineSeconds: 0
   concurrencyPolicy: "Replace"      # Default to "Allow"


### PR DESCRIPTION
 Closes #134 

This PR fixes a cron format error that was causing the workflows to run multiple times with the hour instead of once at the beginning of an hour