### PR TITLE
upgrade to Chapel 1.33.0 and fix permissions error

### DIFF
--- a/arkouda-docker/README.md
+++ b/arkouda-docker/README.md
@@ -13,7 +13,7 @@ and ipython interface to Arkouda. The arkouda-full-stack image extends bearsrus/
 
 ```
 # set env variables
-export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.32.0
+export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.33.0
 export ARKOUDA_BRANCH_NAME=2023.11.15
 export ARKOUDA_DISTRO_NAME=v2023.11.15
 export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.11.15.zip
@@ -49,23 +49,27 @@ To mount a directory containing files to be analyzed, execute the following comm
 export ARKOUDA_IMAGE_REPO=bearsrus
 export ARKOUDA_VERSION=v2023.11.15
 export HOST_DIR=/opt/datafiles
-export CONTAINER_DIR=/app/data
+export CONTAINER_DIR=/home/jovyan
 
 docker run -it --rm -p 8888:8888 --mount type=bind,source=$HOST_DIR,target=$CONTAINER_DIR \
                     $ARKOUDA_IMAGE_REPO/arkouda-full-stack:$ARKOUDA_VERSION
 ```
 
+Important note: setting the CONTAINER\_DIR to /home/jovyan ensures the directory containing files of interest is accessible from the jupyterlab file explorer panel. 
+
 #### Launch with ipython Interface
 
-If preferred, arkouda-full-stack also enables an ipython interface to Arkouda. The corresponding docker launch
-command is as follows:
+If preferred, arkouda-full-stack also enables an ipython interface to Arkouda. The corresponding docker launch command is as follows:
 
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
 export ARKOUDA_VERSION=v2023.11.15
+export HOST_DIR=/opt/datafiles
+export CONTAINER_DIR=/home/jovyan
 
-docker run -it --rm -p 8888:8888 --entrypoint=/opt/arkouda/start-smp-arkouda-full-stack.sh \
+docker run -it --rm -p 8888:8888 --mount type=bind,source=$HOST_DIR,target=$CONTAINER_DIR \
+                    --entrypoint=/opt/arkouda/start-smp-arkouda-full-stack.sh \
                     $ARKOUDA_IMAGE_REPO/arkouda-full-stack:$ARKOUDA_VERSION
 ```
 
@@ -79,7 +83,7 @@ The arkouda-smp-server extends bearsrus/chapel-gasnet-smp to deliver a GASNET sm
 ## Building arkouda-smp-server
 
 ```
-export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.32.0
+export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.33.0
 export ARKOUDA_DISTRO_NAME=v2023.11.15
 export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.11.15.zip
 export ARKOUDA_BRANCH_NAME=2023.11.15
@@ -94,12 +98,17 @@ docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
 
 ## Running arkouda-smp-server
 
+The arkouda-smp-server is launched as follows, optionally with a mounted directory containing files to be analyzed:
+
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
 export ARKOUDA_VERSION=v2023.11.15
+export HOST_DIR=/opt/datafiles
+export CONTAINER_DIR=/opt/files
 
-docker run -it --rm -p 5555:5555 $ARKOUDA_IMAGE_REPO/arkouda-smp-server:$ARKOUDA_VERSION
+docker run -it --rm -p 5555:5555 --mount type=bind,source=$HOST_DIR,target=$CONTAINER_DIR \
+                    $ARKOUDA_IMAGE_REPO/arkouda-smp-server:$ARKOUDA_VERSION
 ```
 
 # chapel-gasnet-udp
@@ -117,7 +126,7 @@ across 1..n locales. Accordingly, the chapel-gasnet-udp image provides a base im
 
 ```
 export CHPL_BASE_IMAGE=ubuntu:22.04
-export CHPL_VERSION=1.32.0
+export CHPL_VERSION=1.33.0
 export CHAPEL_UDP_IMAGE_REPO=bearsrus
 
 docker build --build-arg CHPL_BASE_IMAGE=$CHPL_BASE_IMAGE \
@@ -134,7 +143,7 @@ The arkouda-udp-server image extends bearsrus/chapel-gasnet-udp to deliver a GAS
 ## Building arkouda-udp-server
 
 ```
-export CHAPEL_UDP_IMAGE=bearsrus/chapel-gasnet-udp:1.32.0
+export CHAPEL_UDP_IMAGE=bearsrus/chapel-gasnet-udp:1.33.0
 export ARKOUDA_DISTRO_NAME=v2023.11.15
 export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.11.15.zip
 export ARKOUDA_BRANCH_NAME=2023.11.15
@@ -153,7 +162,7 @@ docker build --build-arg CHAPEL_UDP_IMAGE=$CHAPEL_UDP_IMAGE \
 
 ## Launching arkouda-udp-server
 
-The arkouda-udp-server docker image is designed to be launched on Kubernetes via the bears-r-us [Helm charts](../arkouda-helm-charts).
+The arkouda-udp-server docker image is designed to be launched on Kubernetes via the bears-r-us [Helm charts](../arkouda-helm-charts) ONLY. Consequently, attempting to run the arkouda-udp-server container via ```docker run``` _will not work_.
 
 # prometheus-arkouda-exporter
 
@@ -209,7 +218,7 @@ The arkouda-smp-developer image enables Arkouda developers to mount whichever di
 The arkouda-smp-developer Docker build sequence is very similar to the arkouda-smp-server build sequence, an example of which is shown below:
 
 ```
-export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.32.0
+export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.33.0
 export ARKOUDA_BRANCH_NAME=2023.11.15
 export ARKOUDA_DISTRO_NAME=v2023.11.15
 export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2023.11.15.zip
@@ -246,7 +255,7 @@ Occasionally there are 1..n breaking changes introduced into Arkouda post-releas
 An example arkouda-smp-developer master branch build is as follows:
 
 ```
-export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.32.0
+export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.33.0
 export ARKOUDA_BRANCH_NAME=master
 export ARKOUDA_DISTRO_NAME=master
 export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/heads/master.zip
@@ -299,31 +308,31 @@ Shown below are example build commands. To ensure the optimal, respective perfor
 ### arkouda-full-stack
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.11.15 --chapel_version=1.32.0 --image_type=arkouda-full-stack
+python build_docker_image.py --arkouda_tag=v2023.11.15 --chapel_version=1.33.0 --image_type=arkouda-full-stack
 ```
 
 ### chapel-gasnet-smp
 
 ```
-python build_docker_image.py --chapel_version=1.32.0 --image_type=chapel-gasnet-smp
+python build_docker_image.py --chapel_version=1.33.0 --image_type=chapel-gasnet-smp
 ```
 
 ### arkouda-smp-server
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.11.15 --chapel_version=1.32.0 --image_type=arkouda-smp-server
+python build_docker_image.py --arkouda_tag=v2023.11.15 --chapel_version=1.33.0 --image_type=arkouda-smp-server
 ```
 
 ### chapel-gasnet-udp
 
 ```
-python build_docker_image.py --chapel_version=1.32.0 --image_type=chapel-gasnet-udp
+python build_docker_image.py --chapel_version=1.33.0 --image_type=chapel-gasnet-udp
 ```
 
 ### arkouda-udp-server
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.11.15 --chapel_version=1.32.0 --image_type=arkouda-udp-server
+python build_docker_image.py --arkouda_tag=v2023.11.15 --chapel_version=1.33.0 --image_type=arkouda-udp-server
 ```
 
 ### prometheus-arkouda-exporter
@@ -335,5 +344,5 @@ python build_docker_image.py --arkouda_tag=v2023.11.15 --image_type=prometheus-a
 ### arkouda-smp-developer
 
 ```
-python build_docker_image.py --arkouda_tag=v2023.11.15 --chapel_version=1.32.0 --image_type=arkouda-smp-developer
+python build_docker_image.py --arkouda_tag=v2023.11.15 --chapel_version=1.33.0 --image_type=arkouda-smp-developer
 ```

--- a/arkouda-docker/arkouda-smp-developer
+++ b/arkouda-docker/arkouda-smp-developer
@@ -41,6 +41,8 @@ RUN mkdir object-files && \
 # Add startup script and set entrypoint
 ADD scripts/start-smp-arkouda-server.sh /opt/arkouda/start-smp-arkouda-server.sh
 ADD scripts/start-developer-container.sh /opt/arkouda/start-developer-container.sh
+RUN sudo chmod 755 /opt/arkouda/start-smp-arkouda-server.sh && \
+    sudo chmod 755 /opt/arkouda/start-developer-container.sh
 
 EXPOSE 5555
 


### PR DESCRIPTION
Closes #143 

This PR does the following:

1. upgrades all Arkouda docker images to Chapel 1.33.0
2. fixes newly-discovered permissions errors for arkouda-smp-developer