### PR TITLE
Enable multiple Arkouda-on-Kubernetes instances in the same namespace

### DIFF
--- a/arkouda_workflows/delete-arkouda-on-kubernetes-workflow-template.yaml
+++ b/arkouda_workflows/delete-arkouda-on-kubernetes-workflow-template.yaml
@@ -150,7 +150,7 @@ spec:
         kind: ConfigMap
         apiVersion: v1
         metadata:
-          name: arkouda-server-launch-script
+          name: {{ workflow.parameters.arkouda-instance-name }}-server-launch-script
 
   - name: delete-pod-role
     resource:

--- a/arkouda_workflows/deploy-arkouda-on-kubernetes-workflow-template.yaml
+++ b/arkouda_workflows/deploy-arkouda-on-kubernetes-workflow-template.yaml
@@ -251,9 +251,9 @@ spec:
         kind: ConfigMap
         apiVersion: v1
         metadata:
-          name: arkouda-server-launch-script
+          name: {{ workflow.parameters.arkouda-instance-name }}-server-launch-script
           labels:
-            name: arkouda-server-launch-script
+            name: {{ workflow.parameters.arkouda-instance-name }}-server-launch-script
         data:
           script: |-
   
@@ -393,7 +393,7 @@ spec:
                     secretName: "{{ workflow.parameters.arkouda-ssh-secret }}"
                 - name: arkouda-server-launch-script
                   configMap:
-                    name: arkouda-server-launch-script
+                    name: {{ workflow.parameters.arkouda-instance-name }}-server-launch-script
                     items:
                       - key: script
                         path: start-arkouda-server.sh


### PR DESCRIPTION
Closes #155 

Updates multiple naming conventions to enable 1..n Arkouda-on-Kubernetes (AoK) instances to be deployed in the same namespace.