### PR TITLE
prevent deploy server race condition in arkouda workflows

### DIFF
--- a/arkouda-docker/README.md
+++ b/arkouda-docker/README.md
@@ -2,6 +2,32 @@
 
 The arkouda-docker project delivers Chapel and Arkouda docker images that enable containerized Arkouda to be deployed on Kubernetes, Slurm >= 21.08.5, and bare metal.  
 
+# arkouda-integration
+
+## Background
+
+The arkouda-integration image encapsulates the [arkouda_integration](../arkouda_integration) Python library used to integrate Arkouda with external systems such as Kubernetes.
+
+## Building arkouda-integration
+
+```
+# set env variables
+export ARKOUDA_BRANCH_NAME=2024.04.19
+export ARKOUDA_DISTRO_NAME=v2024.04.19
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2024.04.19.zip
+export ARKOUDA_CONTRIB_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda-contrib/archive/refs/heads/main.zip
+export ARKOUDA_CONTRIB_DISTRO_NAME=main
+export ARKOUDA_INTEGRATION_VERSION=v2024.04.19
+
+docker build --build-arg ARKOUDA_DISTRO_NAME=$ARKOUDA_DISTRO_NAME \
+             --build-arg ARKOUDA_BRANCH_NAME=$ARKOUDA_BRANCH_NAME \
+             --build-arg ARKOUDA_DOWNLOAD_URL=$ARKOUDA_DOWNLOAD_URL \
+             --build-arg ARKOUDA_CONTRIB_DOWNLOAD_URL=$ARKOUDA_CONTRIB_DOWNLOAD_URL \
+             --build-arg ARKOUDA_CONTRIB_DISTRO_NAME=$ARKOUDA_CONTRIB_DISTRO_NAME \
+             -f prometheus-arkouda-exporter -t bearsrus/arkouda-integration:$ARKOUDA_INTEGRATION_VERSION .
+
+```
+
 # arkouda-full-stack
 
 ## Background

--- a/arkouda-docker/README.md
+++ b/arkouda-docker/README.md
@@ -14,9 +14,9 @@ and ipython interface to Arkouda. The arkouda-full-stack image extends bearsrus/
 ```
 # set env variables
 export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.33.0
-export ARKOUDA_BRANCH_NAME=2024.02.02
-export ARKOUDA_DISTRO_NAME=v2024.02.02
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2024.02.02.zip
+export ARKOUDA_BRANCH_NAME=2024.03.18
+export ARKOUDA_DISTRO_NAME=v2024.03.18
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2024.03.18.zip
 export ARKOUDA_IMAGE_REPO=bearsrus
 
 docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
@@ -35,7 +35,7 @@ By default arkouda-full-stack launches a jupyter notebook that is accessible via
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2024.02.02
+export ARKOUDA_VERSION=v2024.03.18
 
 docker run -it --rm -p 8888:8888 $ARKOUDA_IMAGE_REPO/arkouda-full-stack:$ARKOUDA_VERSION
 ```
@@ -47,7 +47,7 @@ To mount a directory containing files to be analyzed, execute the following comm
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2024.02.02
+export ARKOUDA_VERSION=v2024.03.18
 export HOST_DIR=/opt/datafiles
 export CONTAINER_DIR=/home/jovyan
 
@@ -64,7 +64,7 @@ If preferred, arkouda-full-stack also enables an ipython interface to Arkouda. T
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2024.02.02
+export ARKOUDA_VERSION=v2024.03.18
 export HOST_DIR=/opt/datafiles
 export CONTAINER_DIR=/home/jovyan
 
@@ -84,9 +84,9 @@ The arkouda-smp-server extends bearsrus/chapel-gasnet-smp to deliver a GASNET sm
 
 ```
 export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.33.0
-export ARKOUDA_DISTRO_NAME=v2024.02.02
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2024.02.02.zip
-export ARKOUDA_BRANCH_NAME=2024.02.02
+export ARKOUDA_DISTRO_NAME=v2024.03.18
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2024.03.18.zip
+export ARKOUDA_BRANCH_NAME=2024.03.18
 export ARKOUDA_IMAGE_REPO=bearsrus
 
 docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
@@ -103,7 +103,7 @@ The arkouda-smp-server is launched as follows, optionally with a mounted directo
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2024.02.02
+export ARKOUDA_VERSION=v2024.03.18
 export HOST_DIR=/opt/datafiles
 export CONTAINER_DIR=/opt/files
 
@@ -144,9 +144,9 @@ The arkouda-udp-server image extends bearsrus/chapel-gasnet-udp to deliver a GAS
 
 ```
 export CHAPEL_UDP_IMAGE=bearsrus/chapel-gasnet-udp:1.33.0
-export ARKOUDA_DISTRO_NAME=v2024.02.02
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2024.02.02.zip
-export ARKOUDA_BRANCH_NAME=2024.02.02
+export ARKOUDA_DISTRO_NAME=v2024.03.18
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2024.03.18.zip
+export ARKOUDA_BRANCH_NAME=2024.03.18
 export ARKOUDA_INTEGRATION_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda-contrib/archive/refs/heads/main.zip
 export ARKOUDA_INTEGRATION_DISTRO_NAME=main
 export ARKOUDA_IMAGE_REPO=bearsrus
@@ -184,10 +184,10 @@ There are six build arguments passed in to the docker build command:
 An example docker build command sequence is as follows:
 
 ```
-export EXPORTER_VERSION=v2024.02.02
-export ARKOUDA_DISTRO_NAME=v2024.02.02
-export ARKOUDA_BRANCH_NAME=2024.02.02
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2024.02.02.zip
+export EXPORTER_VERSION=v2024.03.18
+export ARKOUDA_DISTRO_NAME=v2024.03.18
+export ARKOUDA_BRANCH_NAME=2024.03.18
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2024.03.18.zip
 export ARKOUDA_CONTRIB_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda-contrib/archive/refs/heads/main.zip
 export ARKOUDA_CONTRIB_DISTRO_NAME=main
 
@@ -202,7 +202,7 @@ docker build --build-arg ARKOUDA_DISTRO_NAME=$ARKOUDA_DISTRO_NAME \
 ## Running prometheus-arkouda-exporter
 
 ```
-export EXPORTER_VERSION=v2024.02.02
+export EXPORTER_VERSION=v2024.03.18
 
 docker run -e ARKOUDA_METRICS_SERVICE_NAME=localhost -e ARKOUDA_METRICS_SERVICE_PORT=5556 -e POLLING_INTERVAL_SECONDS=5 -e EXPORT_PORT=5080 -e EXPORT_PORT=5080 -p 5080:5080 bearsrus/prometheus-arkouda-exporter:$EXPORTER_VERSION
 ```
@@ -219,9 +219,9 @@ The arkouda-smp-developer Docker build sequence is very similar to the arkouda-s
 
 ```
 export CHAPEL_SMP_IMAGE=bearsrus/chapel-gasnet-smp:1.33.0
-export ARKOUDA_BRANCH_NAME=2024.02.02
-export ARKOUDA_DISTRO_NAME=v2024.02.02
-export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2024.02.02.zip
+export ARKOUDA_BRANCH_NAME=2024.03.18
+export ARKOUDA_DISTRO_NAME=v2024.03.18
+export ARKOUDA_DOWNLOAD_URL=https://github.com/Bears-R-Us/arkouda/archive/refs/tags/v2024.03.18.zip
 export ARKOUDA_IMAGE_REPO=bearsrus
 
 docker build --build-arg CHAPEL_SMP_IMAGE=$CHAPEL_SMP_IMAGE \
@@ -238,9 +238,9 @@ Running arkouda-smp-developer with a directory mounted enables building, testing
 ```
 # set env variables
 export ARKOUDA_IMAGE_REPO=bearsrus
-export ARKOUDA_VERSION=v2024.02.02
+export ARKOUDA_VERSION=v2024.03.18
 
-docker run -it --rm -v $PWD/src:/opt/arkouda/src bearsrus/arkouda-smp-developer:v2024.02.02 
+docker run -it --rm -v $PWD/src:/opt/arkouda/src bearsrus/arkouda-smp-developer:v2024.03.18 
 ```
 
 Once the arkouda-smp-developer Docker container is started, any changes to the files within the mounted directory are permanent and retained 
@@ -308,7 +308,7 @@ Shown below are example build commands. To ensure the optimal, respective perfor
 ### arkouda-full-stack
 
 ```
-python build_docker_image.py --arkouda_tag=v2024.02.02 --chapel_version=1.33.0 --image_type=arkouda-full-stack
+python build_docker_image.py --arkouda_tag=v2024.03.18 --chapel_version=1.33.0 --image_type=arkouda-full-stack
 ```
 
 ### chapel-gasnet-smp
@@ -320,7 +320,7 @@ python build_docker_image.py --chapel_version=1.33.0 --image_type=chapel-gasnet-
 ### arkouda-smp-server
 
 ```
-python build_docker_image.py --arkouda_tag=v2024.02.02 --chapel_version=1.33.0 --image_type=arkouda-smp-server
+python build_docker_image.py --arkouda_tag=v2024.03.18 --chapel_version=1.33.0 --image_type=arkouda-smp-server
 ```
 
 ### chapel-gasnet-udp
@@ -332,17 +332,17 @@ python build_docker_image.py --chapel_version=1.33.0 --image_type=chapel-gasnet-
 ### arkouda-udp-server
 
 ```
-python build_docker_image.py --arkouda_tag=v2024.02.02 --chapel_version=1.33.0 --image_type=arkouda-udp-server
+python build_docker_image.py --arkouda_tag=v2024.03.18 --chapel_version=1.33.0 --image_type=arkouda-udp-server
 ```
 
 ### prometheus-arkouda-exporter
 
 ```
-python build_docker_image.py --arkouda_tag=v2024.02.02 --image_type=prometheus-arkouda-exporter
+python build_docker_image.py --arkouda_tag=v2024.03.18 --image_type=prometheus-arkouda-exporter
 ```
 
 ### arkouda-smp-developer
 
 ```
-python build_docker_image.py --arkouda_tag=v2024.02.02 --chapel_version=1.33.0 --image_type=arkouda-smp-developer
+python build_docker_image.py --arkouda_tag=v2024.03.18 --chapel_version=1.33.0 --image_type=arkouda-smp-developer
 ```

--- a/arkouda-docker/arkouda-integration
+++ b/arkouda-docker/arkouda-integration
@@ -1,0 +1,43 @@
+FROM python:3.10-bullseye
+
+WORKDIR /tmp
+
+# Set arkouda and arkouda-contrib env variables from build args
+ARG ARKOUDA_DOWNLOAD_URL=${ARKOUDA_DOWNLOAD_URL}
+ENV ARKOUDA_DOWNLOAD_URL=${ARKOUDA_DOWNLOAD_URL}
+ARG ARKOUDA_DISTRO_NAME=${ARKOUDA_DISTRO_NAME}
+ENV ARKOUDA_DISTRO_NAME=${ARKOUDA_DISTRO_NAME}
+ARG ARKOUDA_BRANCH_NAME=${ARKOUDA_BRANCH_NAME}
+ENV ARKOUDA_BRANCH_NAME=${ARKOUDA_BRANCH_NAME}
+ARG ARKOUDA_CONTRIB_DOWNLOAD_URL=${ARKOUDA_CONTRIB_DOWNLOAD_URL}
+ENV ARKOUDA_CONTRIB_DOWNLOAD_URL=${ARKOUDA_CONTRIB_DOWNLOAD_URL}
+ARG ARKOUDA_CONTRIB_DISTRO_NAME=${ARKOUDA_CONTRIB_DISTRO_NAME}
+ENV ARKOUDA_CONTRIB_DISTRO_NAME=${ARKOUDA_CONTRIB_DISTRO_NAME}
+
+# Install dependencies
+RUN apt-get update && apt upgrade -y && apt-get install unzip -y
+
+# Download arkouda-contrib and arkouda
+RUN wget $ARKOUDA_CONTRIB_DOWNLOAD_URL && \
+    unzip $ARKOUDA_CONTRIB_DISTRO_NAME.zip
+
+RUN wget $ARKOUDA_DOWNLOAD_URL && \
+    unzip $ARKOUDA_DISTRO_NAME.zip
+
+WORKDIR /tmp/arkouda-$ARKOUDA_BRANCH_NAME
+
+# Execute arkouda pip install
+RUN pip install --upgrade pip
+RUN pip install -e .[dev]
+
+WORKDIR /tmp/arkouda-contrib-$ARKOUDA_CONTRIB_DISTRO_NAME/arkouda_integration/client
+
+# Execute arkouda_integrtion pip install
+RUN pip install --upgrade pip
+RUN pip install -e .[dev]
+
+WORKDIR /tmp
+
+RUN rm -rf $ARKOUDA_DISTRO_NAME.zip $ARKOUDA_CONTRIB_DISTRO_NAME.zip
+
+ENTRYPOINT bash

--- a/arkouda_workflows/deploy-arkouda-on-kubernetes-command.sh
+++ b/arkouda_workflows/deploy-arkouda-on-kubernetes-command.sh
@@ -19,7 +19,6 @@ argo submit -n $ARKOUDA_NAMESPACE \
             -p chpl-num-threads-per-locale=$CHPL_NUM_THREADS_PER_LOCALE \
             -p chpl-mem-max=$CHPL_MEM_MAX \
 	    -p arkouda-serviceaccount-name=$ARKOUDA_SERVICEACCOUNT_NAME \
-	    -p arkouda-serviceaccount-token-name=$ARKOUDA_SERVICEACCOUNT_TOKEN_NAME \
 	    -p arkouda-user=$ARKOUDA_USER \
 	    -p arkouda-uid="$ARKOUDA_UID" \
 	    -p arkouda-group=$ARKOUDA_GROUP \

--- a/arkouda_workflows/deploy-arkouda-on-kubernetes-workflow-template.yaml
+++ b/arkouda_workflows/deploy-arkouda-on-kubernetes-workflow-template.yaml
@@ -226,7 +226,12 @@ spec:
       source: |
         import os
         import time
+        os.environ['ARKOUDA_CLIENT_MODE'] = 'API'
+
+        from arkouda.logger import getArkoudaLogger
         from arkouda_integration.k8s import KubernetesDao
+
+        logger = getArkoudaLogger(name="arkouda-locale-verify")
 
         app_name = os.environ['APP_NAME']
         namespace = os.environ['NAMESPACE']
@@ -244,11 +249,11 @@ spec:
         num_deployed_locales = len(dao.get_pod_ips(namespace=namespace, app_name=app_name))
 
         while num_deployed_locales < num_locales:
-            print(f'{num_deployed_locales} of {num_locales} locales deployed')
+            logger.info(f'{num_deployed_locales} of {num_locales} locales deployed')
             time.sleep(5)
             num_deployed_locales = len(dao.get_pod_ips(namespace=namespace, app_name=app_name))
 
-        print(f"{num_locales} locales deployed, arkouda-locale deployment complete")
+        logger.info(f"{num_locales} locales deployed, arkouda-locale deployment complete")
 
   - name: create-locale-headless-service
     resource:

--- a/arkouda_workflows/deploy-arkouda-on-kubernetes-workflow-template.yaml
+++ b/arkouda_workflows/deploy-arkouda-on-kubernetes-workflow-template.yaml
@@ -8,8 +8,6 @@ spec:
     parameters:
     - name: arkouda-serviceaccount-name
       value: arkouda-serviceacccount
-    - name: arkouda-serviceaccount-token-name
-      value: arkouda-serviceaccount-token
     - name: arkouda-user
       value: ubuntu
     - name: arkouda-uid
@@ -45,6 +43,11 @@ spec:
   - name: deploy-arkouda-on-kubernetes
     dag:
       tasks:
+        - name: create-pod-role
+          template: create-pod-role
+        - name: create-pod-role-binding
+          template: create-pod-role-binding
+          depends: 'create-pod-role.Succeeded'
         - name: create-locale-launch-script-config-map
           template: create-locale-launch-script-config-map
         - name: deploy-arkouda-locale
@@ -54,11 +57,9 @@ spec:
           template: create-locale-headless-service
         - name: create-locale-ssh-service
           template: create-locale-ssh-service
-        - name: create-pod-role
-          template: create-pod-role
-        - name: create-pod-role-binding
-          template: create-pod-role-binding
-          depends: 'create-pod-role.Succeeded'
+        - name: verify-locale-deployment
+          template: verify-locale-deployment
+          depends: 'deploy-arkouda-locale.Succeeded'
         - name: create-service-role
           template: create-service-role
         - name: create-service-role-binding
@@ -80,7 +81,7 @@ spec:
           depends: 'deploy-arkouda-locale.Succeeded'
         - name: deploy-arkouda-server
           template: deploy-server
-          depends: 'deploy-arkouda-locale.Succeeded && create-locale-ssh-service.Succeeded && create-locale-headless-service.Succeeded'
+          depends: 'verify-locale-deployment.Succeeded && create-locale-ssh-service.Succeeded && create-locale-headless-service.Succeeded'
         - name: create-metrics-exporter-service
           template: create-metrics-exporter-service
         - name: create-servicemonitor
@@ -200,6 +201,54 @@ spec:
                     items:
                       - key: script
                         path: start-arkouda-locale.sh
+
+  - name: verify-locale-deployment
+    volumes:
+      - name: sa
+        secret:
+          secretName: "{{ workflow.parameters.arkouda-serviceaccount-name }}"
+    script:
+      image: bearsrus/arkouda-integration:{{ workflow.parameters.arkouda-release-version }}
+      imagePullPolicy: "{{ workflow.parameters.image-pull-policy }}" 
+      command: [python3]
+      env:
+        - name: APP_NAME
+          value: "{{ workflow.parameters.arkouda-instance-name }}-locale"
+        - name: NUM_LOCALES
+          value: "{{ workflow.parameters.arkouda-number-of-locales }}"
+        - name: K8S_HOST
+          value: "{{ workflow.parameters.kubernetes-api-url }}"
+        - name: NAMESPACE
+          value: "{{ workflow.parameters.arkouda-namespace }}"
+      volumeMounts:
+        - name: sa
+          mountPath: /opt/sa 
+      source: |
+        import os
+        import time
+        from arkouda_integration.k8s import KubernetesDao
+
+        app_name = os.environ['APP_NAME']
+        namespace = os.environ['NAMESPACE']
+        num_locales = int(os.environ['NUM_LOCALES'])
+        k8s_host = os.environ['K8S_HOST']
+
+        cacert_file = '/opt/sa/ca.crt'
+        with open("/opt/sa/token", "r") as token_file:
+            token = token_file.read()
+
+        dao = KubernetesDao(cacert_file=cacert_file,
+                            token=token,
+                            k8s_host=k8s_host)
+
+        num_deployed_locales = len(dao.get_pod_ips(namespace=namespace, app_name=app_name))
+
+        while num_deployed_locales < num_locales:
+            print(f'{num_deployed_locales} of {num_locales} locales deployed')
+            time.sleep(5)
+            num_deployed_locales = len(dao.get_pod_ips(namespace=namespace, app_name=app_name))
+
+        print(f"{num_locales} locales deployed, arkouda-locale deployment complete")
 
   - name: create-locale-headless-service
     resource:


### PR DESCRIPTION
Closes #168 

This PR delivers the following:

1. arkouda-integration Dockerfile used in the refactored deploy-arkouda-on-kubernetes-workflow-template.yaml to fix an arkouda-server pod race condition
2. verify-locale-deployment step in the deploy-arkouda-on-kubernetes-workflow-template.yaml that ensures all arkouda-locales are deployed prior to starting the arkouda-server pod, thereby fixing the race condition